### PR TITLE
Fix code block contrast in light mode

### DIFF
--- a/src/content/blog/langchain-confusion.mdx
+++ b/src/content/blog/langchain-confusion.mdx
@@ -9,16 +9,23 @@ heroImage: '../../assets/blog_posts/langchain-confusion/michelle-tresemer-MjKUUa
 
 I [built a RAG chatbot with LangChain](/blog/how-to-start-learning-ai.mdx), but the more I look at langchain code, the more I keep confusing myself, specifically with the [RunnableSequence](https://reference.langchain.com/javascript/classes/_langchain_core.runnables.RunnableSequence.html). I just had a breakthrough on why I find it confusing and how I could write it in a way that makes more sense to me.
 
-This example is from [Scrimba's Learn LangChain.js course](https://scrimba.com/learn-langchainjs-c02t), which I highly recommend, and it's free!
+This example is from [Scrimba's Learn LangChain.js course](https://scrimba.com/learn-langchainjs-c02t), which I highly recommend, and it's free! _Note: This is just a portion of the full example code, so you'll see some things are not defined._
 
 ```typescript
-const standaloneQuestionTemplate = `Given some conversation history (if any) and a question, convert the question to a standalone question. 
+/**
+ *  More code above, just not relevant to this example
+ */
+
+const standaloneQuestionTemplate = `Given some conversation history (if any) and a question, convert the question to a standalone question.
 conversation history: {conv_history}
-question: {question} 
+question: {question}
 standalone question:`
 const standaloneQuestionPrompt = PromptTemplate.fromTemplate(
     standaloneQuestionTemplate
 )
+
+const retrieverChain = '' // Similar chain, not important here
+const answerChain = '' // Similar chain, not important here
 
 const standaloneQuestionChain = standaloneQuestionPrompt
     .pipe(llm)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -200,6 +200,11 @@ pre {
 pre > code {
     background: transparent;
     padding: 0;
+    color: inherit;
+}
+/* Ensure Shiki-generated syntax highlighting colors are preserved */
+pre > code span {
+    color: inherit;
 }
 blockquote {
     @apply border-accent-primary bg-bg-secondary border-l-4;


### PR DESCRIPTION
## Problem

Code blocks and ASCII diagrams in blog posts were displaying **dark text on dark background in light mode**, making them completely unreadable.

### Root Cause

- Shiki syntax highlighter applies inline styles with dark theme colors (`background: #24292e`, `color: #e1e4e8`)
- Global CSS was overriding text color with `color: text-text-primary` (dark in light mode)
- Result: dark text on dark background = 0 contrast

## Solution

Updated `src/styles/global.css` to preserve Shiki's inline color styles:

```css
pre > code {
    background: transparent;
    padding: 0;
    color: inherit; /* ← Added */
}

pre > code span {
    color: inherit; /* ← Added */
}
```

## Verification

✅ Tested at mobile (375px), tablet (768px), desktop (1280px) viewports  
✅ Verified proper contrast in both light and dark modes  
✅ Screenshots captured with Playwright MCP  
✅ TypeScript check: 0 errors  
✅ Production build: successful  
✅ WCAG 2.1 AA contrast ratios met

## Additional Improvements

Added clarifying comments to code examples in the LangChain blog post to indicate partial code snippets and prevent reader confusion about undefined variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)