### PR TITLE
Fix blog post list centering on mobile view

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -226,21 +226,22 @@ quote {
         padding: 1.25rem 1.5rem;
     }
 }
-ul,
-ol {
+/* Prose list styles - only apply within prose content */
+.prose ul,
+.prose ol {
     margin: 1em 0;
     padding-left: 2em;
 }
-ul {
+.prose ul {
     list-style-type: disc;
 }
-ol {
+.prose ol {
     list-style-type: decimal;
 }
-li {
+.prose li {
     margin-bottom: 0.5em;
 }
-li::marker {
+.prose li::marker {
     @apply text-accent-primary;
 }
 hr {


### PR DESCRIPTION
## Summary
Fixes horizontal centering issue for blog posts on the `/blog` page at mobile viewport (375px).

## Problem
Blog post list items were not centered properly on mobile because global CSS styles for `ul` and `ol` elements in `src/styles/global.css` were overriding Tailwind utility classes (`list-none`, `p-0`) on the blog index page. The global styles were adding:
- `padding-left: 2em` (causing the list to shift right)
- `list-style-type: disc` (showing unwanted bullet points)

## Solution
Scoped the list styles to only apply within `.prose` containers by changing selectors from:
```css
ul, ol { ... }
ul { list-style-type: disc; }
```
to:
```css
.prose ul, .prose ol { ... }
.prose ul { list-style-type: disc; }
```

This ensures:
1. The blog index page (`/blog`) no longer has unwanted bullet points and padding
2. Blog post content (which uses the `.prose` class) still receives proper list styling with cyan markers

## Files Modified
- `src/styles/global.css` - Scoped list styles to `.prose` containers

## Test Plan
- [x] Verified mobile (375px): Blog posts properly centered with no bullet points
- [x] Verified tablet (768px): 2-column grid layout works correctly
- [x] Verified desktop (1280px): Layout displays properly
- [x] Verified blog post content: Lists still display with proper bullet points and cyan markers
- [x] Build passes: `pnpm build` succeeds
- [x] TypeScript check passes: `pnpm astro check` (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)