### PR TITLE
Add Mastodon verification and Fediverse creator attribution

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -50,6 +50,9 @@ const { title, description, image = '/images/profile.jpg' } = Astro.props
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
 
+<!-- Fediverse -->
+<meta name="fediverse:creator" content="@riccjohn@techhub.social" />
+
 <!-- Analytics -->
 <script
     is:inline

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,4 +16,7 @@ const today = new Date()
         <GitHub hoverable />
         <Email hoverable />
     </div>
+    <a rel="me" href="https://techhub.social/@riccjohn" class="hidden"
+        >Mastodon</a
+    >
 </footer>


### PR DESCRIPTION
- Add hidden rel="me" link in footer for Mastodon account verification
- Add fediverse:creator meta tag for attribution when posts are shared