### PR TITLE
feat: add wrappable code blocks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,33 @@
 // @ts-check
-import { defineConfig } from 'astro/config'
 import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'astro/config'
 
 // https://astro.build/config
 export default defineConfig({
     site: 'https://arcanegrain.dev',
+    markdown: {
+        shikiConfig: {
+            transformers: [
+                {
+                    name: 'wrap-code-blocks',
+                    pre(node) {
+                        const meta = this.options.meta?.__raw ?? ''
+                        if (
+                            meta.split(/\s+/).includes('wrap') &&
+                            typeof node.properties.style === 'string'
+                        ) {
+                            node.properties.style =
+                                node.properties.style.concat(
+                                    ';white-space:pre-wrap;word-break:break-word'
+                                )
+                        }
+                    },
+                },
+            ],
+        },
+    },
     integrations: [mdx(), sitemap()],
     vite: {
         plugins: [tailwindcss()],


### PR DESCRIPTION
## Summary

- Adds a Shiki transformer in `astro.config.mjs` that enables opt-in text wrapping for code blocks
- Code fences marked with the `wrap` meta flag get `white-space:pre-wrap` and `word-break:break-word` applied inline, bypassing Shiki's hardcoded `overflow-x:auto` inline style
- Adds new blog post: *Stop Playing Whac-a-Mole With Your RAG Chatbot*, which uses the feature for its system prompt code block

## Usage

~~~
```text wrap
IMPORTANT: If the context does not contain the answer...
```
~~~

The `wrap` flag can be combined with any language. Only affects the specific code block it's applied to.

## Test plan

- [ ] `pnpm astro check` passes (0 errors)
- [ ] Long single-line code block wraps instead of scrolling on the blog post page
- [ ] Other code blocks (without `wrap`) are unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, config-only change that only affects markdown code block rendering when explicitly opted in via `wrap`.
> 
> **Overview**
> Adds a custom Shiki transformer to Astro’s markdown pipeline so fenced code blocks can *opt-in* to line-wrapping via the `wrap` meta flag.
> 
> When enabled, the transformer appends inline `white-space:pre-wrap` and `word-break:break-word` styles to the `<pre>` element to wrap long lines instead of horizontally scrolling; other code blocks remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03d3b888543cb1d571e763ea5e41404b046d4d7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->