### PR TITLE
Upgrade Astro ecosystem and Tailwind dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
         "prettier:write": "prettier . --write"
     },
     "dependencies": {
-        "@astrojs/check": "^0.9.6",
-        "@astrojs/mdx": "^4.3.13",
-        "@astrojs/rss": "^4.0.15",
-        "@astrojs/sitemap": "^3.7.0",
-        "@tailwindcss/vite": "^4.2.0",
-        "astro": "^5.17.3",
+        "@astrojs/check": "^0.9.8",
+        "@astrojs/mdx": "^4.3.14",
+        "@astrojs/rss": "^4.0.17",
+        "@astrojs/sitemap": "^3.7.1",
+        "@tailwindcss/vite": "^4.2.2",
+        "astro": "^5.18.1",
         "sharp": "^0.34.5",
-        "tailwindcss": "^4.2.0",
+        "tailwindcss": "^4.2.2",
         "typescript": "^5.9.3"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,29 +8,29 @@ importers:
     .:
         dependencies:
             '@astrojs/check':
-                specifier: ^0.9.6
-                version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
+                specifier: ^0.9.8
+                version: 0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
             '@astrojs/mdx':
-                specifier: ^4.3.13
-                version: 4.3.13(astro@5.17.3(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))
+                specifier: ^4.3.14
+                version: 4.3.14(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
             '@astrojs/rss':
-                specifier: ^4.0.15
-                version: 4.0.15
+                specifier: ^4.0.17
+                version: 4.0.17
             '@astrojs/sitemap':
-                specifier: ^3.7.0
-                version: 3.7.0
+                specifier: ^3.7.1
+                version: 3.7.1
             '@tailwindcss/vite':
-                specifier: ^4.2.0
-                version: 4.2.0(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+                specifier: ^4.2.2
+                version: 4.2.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
             astro:
-                specifier: ^5.17.3
-                version: 5.17.3(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
+                specifier: ^5.18.1
+                version: 5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
             sharp:
                 specifier: ^0.34.5
                 version: 0.34.5
             tailwindcss:
-                specifier: ^4.2.0
-                version: 4.2.0
+                specifier: ^4.2.2
+                version: 4.2.2
             typescript:
                 specifier: ^5.9.3
                 version: 5.9.3
@@ -52,10 +52,10 @@ importers:
                 version: 2.13.1
 
 packages:
-    '@astrojs/check@0.9.6':
+    '@astrojs/check@0.9.8':
         resolution:
             {
-                integrity: sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA==,
+                integrity: sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==,
             }
         hasBin: true
         peerDependencies:
@@ -67,16 +67,16 @@ packages:
                 integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==,
             }
 
-    '@astrojs/internal-helpers@0.7.5':
+    '@astrojs/internal-helpers@0.7.6':
         resolution:
             {
-                integrity: sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==,
+                integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==,
             }
 
-    '@astrojs/language-server@2.16.3':
+    '@astrojs/language-server@2.16.6':
         resolution:
             {
-                integrity: sha512-yO5K7RYCMXUfeDlnU6UnmtnoXzpuQc0yhlaCNZ67k1C/MiwwwvMZz+LGa+H35c49w5QBfvtr4w4Zcf5PcH8uYA==,
+                integrity: sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug==,
             }
         hasBin: true
         peerDependencies:
@@ -88,16 +88,16 @@ packages:
             prettier-plugin-astro:
                 optional: true
 
-    '@astrojs/markdown-remark@6.3.10':
+    '@astrojs/markdown-remark@6.3.11':
         resolution:
             {
-                integrity: sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==,
+                integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==,
             }
 
-    '@astrojs/mdx@4.3.13':
+    '@astrojs/mdx@4.3.14':
         resolution:
             {
-                integrity: sha512-IHDHVKz0JfKBy3//52JSiyWv089b7GVSChIXLrlUOoTLWowG3wr2/8hkaEgEyd/vysvNQvGk+QhysXpJW5ve6Q==,
+                integrity: sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA==,
             }
         engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
         peerDependencies:
@@ -110,16 +110,16 @@ packages:
             }
         engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
-    '@astrojs/rss@4.0.15':
+    '@astrojs/rss@4.0.17':
         resolution:
             {
-                integrity: sha512-uXO/k6AhRkIDXmRoc6xQpoPZrimQNUmS43X4+60yunfuMNHtSRN5e/FiSi7NApcZqmugSMc5+cJi8ovqgO+qIg==,
+                integrity: sha512-eV+wdMbeVKC9+sPaV0LN8JL1LGo9YAh3GKl4Ou4nzMNLmXM/aswYpSGxVEAuHilgBZ6/++/Pv08ICmuOqX107w==,
             }
 
-    '@astrojs/sitemap@3.7.0':
+    '@astrojs/sitemap@3.7.1':
         resolution:
             {
-                integrity: sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==,
+                integrity: sha512-IzQqdTeskaMX+QDZCzMuJIp8A8C1vgzMBp/NmHNnadepHYNHcxQdGLQZYfkbd2EbRXUfOS+UDIKx8sKg0oWVdw==,
             }
 
     '@astrojs/telemetry@3.3.0':
@@ -129,10 +129,10 @@ packages:
             }
         engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
-    '@astrojs/yaml2ts@0.2.2':
+    '@astrojs/yaml2ts@0.2.3':
         resolution:
             {
-                integrity: sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==,
+                integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==,
             }
 
     '@babel/helper-string-parser@7.27.1':
@@ -149,10 +149,10 @@ packages:
             }
         engines: { node: '>=6.9.0' }
 
-    '@babel/parser@7.29.0':
+    '@babel/parser@7.29.2':
         resolution:
             {
-                integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==,
+                integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
             }
         engines: { node: '>=6.0.0' }
         hasBin: true
@@ -213,10 +213,10 @@ packages:
                 integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==,
             }
 
-    '@emnapi/runtime@1.8.1':
+    '@emnapi/runtime@1.9.1':
         resolution:
             {
-                integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==,
+                integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==,
             }
 
     '@esbuild/aix-ppc64@0.25.12':
@@ -228,10 +228,10 @@ packages:
         cpu: [ppc64]
         os: [aix]
 
-    '@esbuild/aix-ppc64@0.27.3':
+    '@esbuild/aix-ppc64@0.27.4':
         resolution:
             {
-                integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==,
+                integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==,
             }
         engines: { node: '>=18' }
         cpu: [ppc64]
@@ -246,10 +246,10 @@ packages:
         cpu: [arm64]
         os: [android]
 
-    '@esbuild/android-arm64@0.27.3':
+    '@esbuild/android-arm64@0.27.4':
         resolution:
             {
-                integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==,
+                integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
@@ -264,10 +264,10 @@ packages:
         cpu: [arm]
         os: [android]
 
-    '@esbuild/android-arm@0.27.3':
+    '@esbuild/android-arm@0.27.4':
         resolution:
             {
-                integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==,
+                integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==,
             }
         engines: { node: '>=18' }
         cpu: [arm]
@@ -282,10 +282,10 @@ packages:
         cpu: [x64]
         os: [android]
 
-    '@esbuild/android-x64@0.27.3':
+    '@esbuild/android-x64@0.27.4':
         resolution:
             {
-                integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==,
+                integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
@@ -300,10 +300,10 @@ packages:
         cpu: [arm64]
         os: [darwin]
 
-    '@esbuild/darwin-arm64@0.27.3':
+    '@esbuild/darwin-arm64@0.27.4':
         resolution:
             {
-                integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==,
+                integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
@@ -318,10 +318,10 @@ packages:
         cpu: [x64]
         os: [darwin]
 
-    '@esbuild/darwin-x64@0.27.3':
+    '@esbuild/darwin-x64@0.27.4':
         resolution:
             {
-                integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==,
+                integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
@@ -336,10 +336,10 @@ packages:
         cpu: [arm64]
         os: [freebsd]
 
-    '@esbuild/freebsd-arm64@0.27.3':
+    '@esbuild/freebsd-arm64@0.27.4':
         resolution:
             {
-                integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==,
+                integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
@@ -354,10 +354,10 @@ packages:
         cpu: [x64]
         os: [freebsd]
 
-    '@esbuild/freebsd-x64@0.27.3':
+    '@esbuild/freebsd-x64@0.27.4':
         resolution:
             {
-                integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==,
+                integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
@@ -372,10 +372,10 @@ packages:
         cpu: [arm64]
         os: [linux]
 
-    '@esbuild/linux-arm64@0.27.3':
+    '@esbuild/linux-arm64@0.27.4':
         resolution:
             {
-                integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==,
+                integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
@@ -390,10 +390,10 @@ packages:
         cpu: [arm]
         os: [linux]
 
-    '@esbuild/linux-arm@0.27.3':
+    '@esbuild/linux-arm@0.27.4':
         resolution:
             {
-                integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==,
+                integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==,
             }
         engines: { node: '>=18' }
         cpu: [arm]
@@ -408,10 +408,10 @@ packages:
         cpu: [ia32]
         os: [linux]
 
-    '@esbuild/linux-ia32@0.27.3':
+    '@esbuild/linux-ia32@0.27.4':
         resolution:
             {
-                integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==,
+                integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==,
             }
         engines: { node: '>=18' }
         cpu: [ia32]
@@ -426,10 +426,10 @@ packages:
         cpu: [loong64]
         os: [linux]
 
-    '@esbuild/linux-loong64@0.27.3':
+    '@esbuild/linux-loong64@0.27.4':
         resolution:
             {
-                integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==,
+                integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==,
             }
         engines: { node: '>=18' }
         cpu: [loong64]
@@ -444,10 +444,10 @@ packages:
         cpu: [mips64el]
         os: [linux]
 
-    '@esbuild/linux-mips64el@0.27.3':
+    '@esbuild/linux-mips64el@0.27.4':
         resolution:
             {
-                integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==,
+                integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==,
             }
         engines: { node: '>=18' }
         cpu: [mips64el]
@@ -462,10 +462,10 @@ packages:
         cpu: [ppc64]
         os: [linux]
 
-    '@esbuild/linux-ppc64@0.27.3':
+    '@esbuild/linux-ppc64@0.27.4':
         resolution:
             {
-                integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==,
+                integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==,
             }
         engines: { node: '>=18' }
         cpu: [ppc64]
@@ -480,10 +480,10 @@ packages:
         cpu: [riscv64]
         os: [linux]
 
-    '@esbuild/linux-riscv64@0.27.3':
+    '@esbuild/linux-riscv64@0.27.4':
         resolution:
             {
-                integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==,
+                integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==,
             }
         engines: { node: '>=18' }
         cpu: [riscv64]
@@ -498,10 +498,10 @@ packages:
         cpu: [s390x]
         os: [linux]
 
-    '@esbuild/linux-s390x@0.27.3':
+    '@esbuild/linux-s390x@0.27.4':
         resolution:
             {
-                integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==,
+                integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==,
             }
         engines: { node: '>=18' }
         cpu: [s390x]
@@ -516,10 +516,10 @@ packages:
         cpu: [x64]
         os: [linux]
 
-    '@esbuild/linux-x64@0.27.3':
+    '@esbuild/linux-x64@0.27.4':
         resolution:
             {
-                integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==,
+                integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
@@ -534,10 +534,10 @@ packages:
         cpu: [arm64]
         os: [netbsd]
 
-    '@esbuild/netbsd-arm64@0.27.3':
+    '@esbuild/netbsd-arm64@0.27.4':
         resolution:
             {
-                integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==,
+                integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
@@ -552,10 +552,10 @@ packages:
         cpu: [x64]
         os: [netbsd]
 
-    '@esbuild/netbsd-x64@0.27.3':
+    '@esbuild/netbsd-x64@0.27.4':
         resolution:
             {
-                integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==,
+                integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
@@ -570,10 +570,10 @@ packages:
         cpu: [arm64]
         os: [openbsd]
 
-    '@esbuild/openbsd-arm64@0.27.3':
+    '@esbuild/openbsd-arm64@0.27.4':
         resolution:
             {
-                integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==,
+                integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
@@ -588,10 +588,10 @@ packages:
         cpu: [x64]
         os: [openbsd]
 
-    '@esbuild/openbsd-x64@0.27.3':
+    '@esbuild/openbsd-x64@0.27.4':
         resolution:
             {
-                integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==,
+                integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
@@ -606,10 +606,10 @@ packages:
         cpu: [arm64]
         os: [openharmony]
 
-    '@esbuild/openharmony-arm64@0.27.3':
+    '@esbuild/openharmony-arm64@0.27.4':
         resolution:
             {
-                integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==,
+                integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
@@ -624,10 +624,10 @@ packages:
         cpu: [x64]
         os: [sunos]
 
-    '@esbuild/sunos-x64@0.27.3':
+    '@esbuild/sunos-x64@0.27.4':
         resolution:
             {
-                integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==,
+                integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
@@ -642,10 +642,10 @@ packages:
         cpu: [arm64]
         os: [win32]
 
-    '@esbuild/win32-arm64@0.27.3':
+    '@esbuild/win32-arm64@0.27.4':
         resolution:
             {
-                integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==,
+                integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
@@ -660,10 +660,10 @@ packages:
         cpu: [ia32]
         os: [win32]
 
-    '@esbuild/win32-ia32@0.27.3':
+    '@esbuild/win32-ia32@0.27.4':
         resolution:
             {
-                integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==,
+                integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==,
             }
         engines: { node: '>=18' }
         cpu: [ia32]
@@ -678,19 +678,19 @@ packages:
         cpu: [x64]
         os: [win32]
 
-    '@esbuild/win32-x64@0.27.3':
+    '@esbuild/win32-x64@0.27.4':
         resolution:
             {
-                integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==,
+                integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
         os: [win32]
 
-    '@img/colour@1.0.0':
+    '@img/colour@1.1.0':
         resolution:
             {
-                integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==,
+                integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
             }
         engines: { node: '>=18' }
 
@@ -977,253 +977,253 @@ packages:
             rollup:
                 optional: true
 
-    '@rollup/rollup-android-arm-eabi@4.57.1':
+    '@rollup/rollup-android-arm-eabi@4.59.0':
         resolution:
             {
-                integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==,
+                integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==,
             }
         cpu: [arm]
         os: [android]
 
-    '@rollup/rollup-android-arm64@4.57.1':
+    '@rollup/rollup-android-arm64@4.59.0':
         resolution:
             {
-                integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==,
+                integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==,
             }
         cpu: [arm64]
         os: [android]
 
-    '@rollup/rollup-darwin-arm64@4.57.1':
+    '@rollup/rollup-darwin-arm64@4.59.0':
         resolution:
             {
-                integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==,
+                integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==,
             }
         cpu: [arm64]
         os: [darwin]
 
-    '@rollup/rollup-darwin-x64@4.57.1':
+    '@rollup/rollup-darwin-x64@4.59.0':
         resolution:
             {
-                integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==,
+                integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==,
             }
         cpu: [x64]
         os: [darwin]
 
-    '@rollup/rollup-freebsd-arm64@4.57.1':
+    '@rollup/rollup-freebsd-arm64@4.59.0':
         resolution:
             {
-                integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==,
+                integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==,
             }
         cpu: [arm64]
         os: [freebsd]
 
-    '@rollup/rollup-freebsd-x64@4.57.1':
+    '@rollup/rollup-freebsd-x64@4.59.0':
         resolution:
             {
-                integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==,
+                integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==,
             }
         cpu: [x64]
         os: [freebsd]
 
-    '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
         resolution:
             {
-                integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==,
+                integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==,
             }
         cpu: [arm]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    '@rollup/rollup-linux-arm-musleabihf@4.59.0':
         resolution:
             {
-                integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==,
+                integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==,
             }
         cpu: [arm]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    '@rollup/rollup-linux-arm64-gnu@4.59.0':
         resolution:
             {
-                integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==,
+                integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==,
             }
         cpu: [arm64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-arm64-musl@4.57.1':
+    '@rollup/rollup-linux-arm64-musl@4.59.0':
         resolution:
             {
-                integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==,
+                integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==,
             }
         cpu: [arm64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    '@rollup/rollup-linux-loong64-gnu@4.59.0':
         resolution:
             {
-                integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==,
+                integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==,
             }
         cpu: [loong64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-loong64-musl@4.57.1':
+    '@rollup/rollup-linux-loong64-musl@4.59.0':
         resolution:
             {
-                integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==,
+                integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==,
             }
         cpu: [loong64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    '@rollup/rollup-linux-ppc64-gnu@4.59.0':
         resolution:
             {
-                integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==,
+                integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==,
             }
         cpu: [ppc64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    '@rollup/rollup-linux-ppc64-musl@4.59.0':
         resolution:
             {
-                integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==,
+                integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==,
             }
         cpu: [ppc64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    '@rollup/rollup-linux-riscv64-gnu@4.59.0':
         resolution:
             {
-                integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==,
+                integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==,
             }
         cpu: [riscv64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    '@rollup/rollup-linux-riscv64-musl@4.59.0':
         resolution:
             {
-                integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==,
+                integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==,
             }
         cpu: [riscv64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    '@rollup/rollup-linux-s390x-gnu@4.59.0':
         resolution:
             {
-                integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==,
+                integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==,
             }
         cpu: [s390x]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-x64-gnu@4.57.1':
+    '@rollup/rollup-linux-x64-gnu@4.59.0':
         resolution:
             {
-                integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==,
+                integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==,
             }
         cpu: [x64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-x64-musl@4.57.1':
+    '@rollup/rollup-linux-x64-musl@4.59.0':
         resolution:
             {
-                integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==,
+                integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==,
             }
         cpu: [x64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-openbsd-x64@4.57.1':
+    '@rollup/rollup-openbsd-x64@4.59.0':
         resolution:
             {
-                integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==,
+                integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==,
             }
         cpu: [x64]
         os: [openbsd]
 
-    '@rollup/rollup-openharmony-arm64@4.57.1':
+    '@rollup/rollup-openharmony-arm64@4.59.0':
         resolution:
             {
-                integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==,
+                integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==,
             }
         cpu: [arm64]
         os: [openharmony]
 
-    '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    '@rollup/rollup-win32-arm64-msvc@4.59.0':
         resolution:
             {
-                integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==,
+                integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==,
             }
         cpu: [arm64]
         os: [win32]
 
-    '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    '@rollup/rollup-win32-ia32-msvc@4.59.0':
         resolution:
             {
-                integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==,
+                integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==,
             }
         cpu: [ia32]
         os: [win32]
 
-    '@rollup/rollup-win32-x64-gnu@4.57.1':
+    '@rollup/rollup-win32-x64-gnu@4.59.0':
         resolution:
             {
-                integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==,
+                integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==,
             }
         cpu: [x64]
         os: [win32]
 
-    '@rollup/rollup-win32-x64-msvc@4.57.1':
+    '@rollup/rollup-win32-x64-msvc@4.59.0':
         resolution:
             {
-                integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==,
+                integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==,
             }
         cpu: [x64]
         os: [win32]
 
-    '@shikijs/core@3.22.0':
+    '@shikijs/core@3.23.0':
         resolution:
             {
-                integrity: sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==,
+                integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
             }
 
-    '@shikijs/engine-javascript@3.22.0':
+    '@shikijs/engine-javascript@3.23.0':
         resolution:
             {
-                integrity: sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==,
+                integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
             }
 
-    '@shikijs/engine-oniguruma@3.22.0':
+    '@shikijs/engine-oniguruma@3.23.0':
         resolution:
             {
-                integrity: sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==,
+                integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
             }
 
-    '@shikijs/langs@3.22.0':
+    '@shikijs/langs@3.23.0':
         resolution:
             {
-                integrity: sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==,
+                integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
             }
 
-    '@shikijs/themes@3.22.0':
+    '@shikijs/themes@3.23.0':
         resolution:
             {
-                integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==,
+                integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
             }
 
-    '@shikijs/types@3.22.0':
+    '@shikijs/types@3.23.0':
         resolution:
             {
-                integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==,
+                integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
             }
 
     '@shikijs/vscode-textmate@10.0.2':
@@ -1232,101 +1232,101 @@ packages:
                 integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==,
             }
 
-    '@tailwindcss/node@4.2.0':
+    '@tailwindcss/node@4.2.2':
         resolution:
             {
-                integrity: sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q==,
+                integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==,
             }
 
-    '@tailwindcss/oxide-android-arm64@4.2.0':
+    '@tailwindcss/oxide-android-arm64@4.2.2':
         resolution:
             {
-                integrity: sha512-F0QkHAVaW/JNBWl4CEKWdZ9PMb0khw5DCELAOnu+RtjAfx5Zgw+gqCHFvqg3AirU1IAd181fwOtJQ5I8Yx5wtw==,
+                integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==,
             }
         engines: { node: '>= 20' }
         cpu: [arm64]
         os: [android]
 
-    '@tailwindcss/oxide-darwin-arm64@4.2.0':
+    '@tailwindcss/oxide-darwin-arm64@4.2.2':
         resolution:
             {
-                integrity: sha512-I0QylkXsBsJMZ4nkUNSR04p6+UptjcwhcVo3Zu828ikiEqHjVmQL9RuQ6uT/cVIiKpvtVA25msu/eRV97JeNSA==,
+                integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==,
             }
         engines: { node: '>= 20' }
         cpu: [arm64]
         os: [darwin]
 
-    '@tailwindcss/oxide-darwin-x64@4.2.0':
+    '@tailwindcss/oxide-darwin-x64@4.2.2':
         resolution:
             {
-                integrity: sha512-6TmQIn4p09PBrmnkvbYQ0wbZhLtbaksCDx7Y7R3FYYx0yxNA7xg5KP7dowmQ3d2JVdabIHvs3Hx4K3d5uCf8xg==,
+                integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==,
             }
         engines: { node: '>= 20' }
         cpu: [x64]
         os: [darwin]
 
-    '@tailwindcss/oxide-freebsd-x64@4.2.0':
+    '@tailwindcss/oxide-freebsd-x64@4.2.2':
         resolution:
             {
-                integrity: sha512-qBudxDvAa2QwGlq9y7VIzhTvp2mLJ6nD/G8/tI70DCDoneaUeLWBJaPcbfzqRIWraj+o969aDQKvKW9dvkUizw==,
+                integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==,
             }
         engines: { node: '>= 20' }
         cpu: [x64]
         os: [freebsd]
 
-    '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.0':
+    '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
         resolution:
             {
-                integrity: sha512-7XKkitpy5NIjFZNUQPeUyNJNJn1CJeV7rmMR+exHfTuOsg8rxIO9eNV5TSEnqRcaOK77zQpsyUkBWmPy8FgdSg==,
+                integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==,
             }
         engines: { node: '>= 20' }
         cpu: [arm]
         os: [linux]
 
-    '@tailwindcss/oxide-linux-arm64-gnu@4.2.0':
+    '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
         resolution:
             {
-                integrity: sha512-Mff5a5Q3WoQR01pGU1gr29hHM1N93xYrKkGXfPw/aRtK4bOc331Ho4Tgfsm5WDGvpevqMpdlkCojT3qlCQbCpA==,
+                integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==,
             }
         engines: { node: '>= 20' }
         cpu: [arm64]
         os: [linux]
         libc: [glibc]
 
-    '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
+    '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
         resolution:
             {
-                integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==,
+                integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==,
             }
         engines: { node: '>= 20' }
         cpu: [arm64]
         os: [linux]
         libc: [musl]
 
-    '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
+    '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
         resolution:
             {
-                integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==,
+                integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==,
             }
         engines: { node: '>= 20' }
         cpu: [x64]
         os: [linux]
         libc: [glibc]
 
-    '@tailwindcss/oxide-linux-x64-musl@4.2.0':
+    '@tailwindcss/oxide-linux-x64-musl@4.2.2':
         resolution:
             {
-                integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==,
+                integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==,
             }
         engines: { node: '>= 20' }
         cpu: [x64]
         os: [linux]
         libc: [musl]
 
-    '@tailwindcss/oxide-wasm32-wasi@4.2.0':
+    '@tailwindcss/oxide-wasm32-wasi@4.2.2':
         resolution:
             {
-                integrity: sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==,
+                integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==,
             }
         engines: { node: '>=14.0.0' }
         cpu: [wasm32]
@@ -1338,43 +1338,43 @@ packages:
             - '@emnapi/wasi-threads'
             - tslib
 
-    '@tailwindcss/oxide-win32-arm64-msvc@4.2.0':
+    '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
         resolution:
             {
-                integrity: sha512-2UU/15y1sWDEDNJXxEIrfWKC2Yb4YgIW5Xz2fKFqGzFWfoMHWFlfa1EJlGO2Xzjkq/tvSarh9ZTjvbxqWvLLXA==,
+                integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==,
             }
         engines: { node: '>= 20' }
         cpu: [arm64]
         os: [win32]
 
-    '@tailwindcss/oxide-win32-x64-msvc@4.2.0':
+    '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
         resolution:
             {
-                integrity: sha512-CrFadmFoc+z76EV6LPG1jx6XceDsaCG3lFhyLNo/bV9ByPrE+FnBPckXQVP4XRkN76h3Fjt/a+5Er/oA/nCBvQ==,
+                integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==,
             }
         engines: { node: '>= 20' }
         cpu: [x64]
         os: [win32]
 
-    '@tailwindcss/oxide@4.2.0':
+    '@tailwindcss/oxide@4.2.2':
         resolution:
             {
-                integrity: sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ==,
+                integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==,
             }
         engines: { node: '>= 20' }
 
-    '@tailwindcss/vite@4.2.0':
+    '@tailwindcss/vite@4.2.2':
         resolution:
             {
-                integrity: sha512-da9mFCaHpoOgtQiWtDGIikTrSpUFBtIZCG3jy/u2BGV+l/X1/pbxzmIUxNt6JWm19N3WtGi4KlJdSH/Si83WOA==,
+                integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==,
             }
         peerDependencies:
-            vite: ^5.2.0 || ^6 || ^7
+            vite: ^5.2.0 || ^6 || ^7 || ^8
 
-    '@types/debug@4.1.12':
+    '@types/debug@4.1.13':
         resolution:
             {
-                integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==,
+                integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
             }
 
     '@types/estree-jsx@1.0.5':
@@ -1419,16 +1419,10 @@ packages:
                 integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==,
             }
 
-    '@types/node@17.0.45':
+    '@types/node@24.12.0':
         resolution:
             {
-                integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==,
-            }
-
-    '@types/node@24.3.0':
-        resolution:
-            {
-                integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==,
+                integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==,
             }
 
     '@types/sax@1.2.7':
@@ -1611,10 +1605,10 @@ packages:
             }
         hasBin: true
 
-    astro@5.17.3:
+    astro@5.18.1:
         resolution:
             {
-                integrity: sha512-69dcfPe8LsHzklwj+hl+vunWUbpMB6pmg35mACjetxbJeUNNys90JaBM8ZiwsPK689SAj/4Zqb1ayaANls9/MA==,
+                integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==,
             }
         engines:
             {
@@ -1813,10 +1807,10 @@ packages:
         engines:
             { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0' }
 
-    css-tree@3.1.0:
+    css-tree@3.2.1:
         resolution:
             {
-                integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==,
+                integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
             }
         engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
 
@@ -1894,10 +1888,10 @@ packages:
             }
         engines: { node: '>=18' }
 
-    devalue@5.6.3:
+    devalue@5.6.4:
         resolution:
             {
-                integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==,
+                integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==,
             }
 
     devlop@1.1.0:
@@ -1969,10 +1963,10 @@ packages:
                 integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
             }
 
-    enhanced-resolve@5.19.0:
+    enhanced-resolve@5.20.1:
         resolution:
             {
-                integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==,
+                integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==,
             }
         engines: { node: '>=10.13.0' }
 
@@ -2016,10 +2010,10 @@ packages:
         engines: { node: '>=18' }
         hasBin: true
 
-    esbuild@0.27.3:
+    esbuild@0.27.4:
         resolution:
             {
-                integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==,
+                integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==,
             }
         engines: { node: '>=18' }
         hasBin: true
@@ -2110,10 +2104,16 @@ packages:
                 integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
             }
 
-    fast-xml-parser@5.3.6:
+    fast-xml-builder@1.1.4:
         resolution:
             {
-                integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==,
+                integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==,
+            }
+
+    fast-xml-parser@5.4.1:
+        resolution:
+            {
+                integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==,
             }
         hasBin: true
 
@@ -2142,10 +2142,10 @@ packages:
                 integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==,
             }
 
-    fontkitten@1.0.2:
+    fontkitten@1.0.3:
         resolution:
             {
-                integrity: sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q==,
+                integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==,
             }
         engines: { node: '>=20' }
 
@@ -2183,10 +2183,10 @@ packages:
                 integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
             }
 
-    h3@1.15.5:
+    h3@1.15.9:
         resolution:
             {
-                integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==,
+                integrity: sha512-H7UPnyIupUOYUQu7f2x7ABVeMyF/IbJjqn20WSXpMdnQB260luADUkSgJU7QTWLutq8h3tUayMQ1DdbSYX5LkA==,
             }
 
     hast-util-from-html@2.0.3:
@@ -2411,121 +2411,115 @@ packages:
             }
         engines: { node: '>=6' }
 
-    lightningcss-android-arm64@1.31.1:
+    lightningcss-android-arm64@1.32.0:
         resolution:
             {
-                integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==,
+                integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [arm64]
         os: [android]
 
-    lightningcss-darwin-arm64@1.31.1:
+    lightningcss-darwin-arm64@1.32.0:
         resolution:
             {
-                integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==,
+                integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [arm64]
         os: [darwin]
 
-    lightningcss-darwin-x64@1.31.1:
+    lightningcss-darwin-x64@1.32.0:
         resolution:
             {
-                integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==,
+                integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [x64]
         os: [darwin]
 
-    lightningcss-freebsd-x64@1.31.1:
+    lightningcss-freebsd-x64@1.32.0:
         resolution:
             {
-                integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==,
+                integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [x64]
         os: [freebsd]
 
-    lightningcss-linux-arm-gnueabihf@1.31.1:
+    lightningcss-linux-arm-gnueabihf@1.32.0:
         resolution:
             {
-                integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==,
+                integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [arm]
         os: [linux]
 
-    lightningcss-linux-arm64-gnu@1.31.1:
+    lightningcss-linux-arm64-gnu@1.32.0:
         resolution:
             {
-                integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==,
+                integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [arm64]
         os: [linux]
         libc: [glibc]
 
-    lightningcss-linux-arm64-musl@1.31.1:
+    lightningcss-linux-arm64-musl@1.32.0:
         resolution:
             {
-                integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==,
+                integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [arm64]
         os: [linux]
         libc: [musl]
 
-    lightningcss-linux-x64-gnu@1.31.1:
+    lightningcss-linux-x64-gnu@1.32.0:
         resolution:
             {
-                integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==,
+                integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [x64]
         os: [linux]
         libc: [glibc]
 
-    lightningcss-linux-x64-musl@1.31.1:
+    lightningcss-linux-x64-musl@1.32.0:
         resolution:
             {
-                integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==,
+                integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [x64]
         os: [linux]
         libc: [musl]
 
-    lightningcss-win32-arm64-msvc@1.31.1:
+    lightningcss-win32-arm64-msvc@1.32.0:
         resolution:
             {
-                integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==,
+                integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [arm64]
         os: [win32]
 
-    lightningcss-win32-x64-msvc@1.31.1:
+    lightningcss-win32-x64-msvc@1.32.0:
         resolution:
             {
-                integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==,
+                integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
             }
         engines: { node: '>= 12.0.0' }
         cpu: [x64]
         os: [win32]
 
-    lightningcss@1.31.1:
+    lightningcss@1.32.0:
         resolution:
             {
-                integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==,
+                integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
             }
         engines: { node: '>= 12.0.0' }
-
-    lodash@4.17.21:
-        resolution:
-            {
-                integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
-            }
 
     longest-streak@3.1.0:
         resolution:
@@ -2533,10 +2527,10 @@ packages:
                 integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
             }
 
-    lru-cache@11.2.6:
+    lru-cache@11.2.7:
         resolution:
             {
-                integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==,
+                integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==,
             }
         engines: { node: 20 || >=22 }
 
@@ -2577,10 +2571,10 @@ packages:
                 integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==,
             }
 
-    mdast-util-from-markdown@2.0.2:
+    mdast-util-from-markdown@2.0.3:
         resolution:
             {
-                integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==,
+                integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
             }
 
     mdast-util-gfm-autolink-literal@2.0.1:
@@ -2673,10 +2667,10 @@ packages:
                 integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==,
             }
 
-    mdn-data@2.12.2:
+    mdn-data@2.27.1:
         resolution:
             {
-                integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==,
+                integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
             }
 
     micromark-core-commonmark@2.0.3:
@@ -2979,10 +2973,10 @@ packages:
                 integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==,
             }
 
-    oniguruma-to-es@4.3.4:
+    oniguruma-to-es@4.3.5:
         resolution:
             {
-                integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==,
+                integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==,
             }
 
     p-limit@6.2.0:
@@ -3036,6 +3030,13 @@ packages:
                 integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==,
             }
 
+    path-expression-matcher@1.2.0:
+        resolution:
+            {
+                integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==,
+            }
+        engines: { node: '>=14.0.0' }
+
     piccolore@0.1.3:
         resolution:
             {
@@ -3062,10 +3063,10 @@ packages:
             }
         engines: { node: '>=12' }
 
-    postcss@8.5.6:
+    postcss@8.5.8:
         resolution:
             {
-                integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
+                integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
             }
         engines: { node: ^10 || ^12 || >=14 }
 
@@ -3359,10 +3360,10 @@ packages:
                 integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==,
             }
 
-    rollup@4.57.1:
+    rollup@4.59.0:
         resolution:
             {
-                integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==,
+                integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==,
             }
         engines: { node: '>=18.0.0', npm: '>=8.0.0' }
         hasBin: true
@@ -3379,10 +3380,10 @@ packages:
                 integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==,
             }
 
-    sax@1.4.4:
+    sax@1.6.0:
         resolution:
             {
-                integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==,
+                integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==,
             }
         engines: { node: '>=11.0.0' }
 
@@ -3401,10 +3402,10 @@ packages:
             }
         engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
 
-    shiki@3.22.0:
+    shiki@3.23.0:
         resolution:
             {
-                integrity: sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==,
+                integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
             }
 
     simple-git-hooks@2.13.1:
@@ -3420,12 +3421,12 @@ packages:
                 integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
             }
 
-    sitemap@8.0.2:
+    sitemap@9.0.1:
         resolution:
             {
-                integrity: sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==,
+                integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==,
             }
-        engines: { node: '>=14.0.0', npm: '>=6.0.0' }
+        engines: { node: '>=20.19.5', npm: '>=10.8.2' }
         hasBin: true
 
     smol-toml@1.6.0:
@@ -3488,17 +3489,17 @@ packages:
             }
         engines: { node: '>=8' }
 
-    strip-ansi@7.1.2:
+    strip-ansi@7.2.0:
         resolution:
             {
-                integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==,
+                integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
             }
         engines: { node: '>=12' }
 
-    strnum@2.1.2:
+    strnum@2.2.1:
         resolution:
             {
-                integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==,
+                integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==,
             }
 
     style-to-js@1.1.21:
@@ -3519,18 +3520,18 @@ packages:
                 integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==,
             }
 
-    svgo@4.0.0:
+    svgo@4.0.1:
         resolution:
             {
-                integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==,
+                integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==,
             }
         engines: { node: '>=16' }
         hasBin: true
 
-    tailwindcss@4.2.0:
+    tailwindcss@4.2.2:
         resolution:
             {
-                integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==,
+                integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==,
             }
 
     tapable@2.3.0:
@@ -3552,10 +3553,10 @@ packages:
                 integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
             }
 
-    tinyexec@1.0.2:
+    tinyexec@1.0.4:
         resolution:
             {
-                integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==,
+                integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==,
             }
         engines: { node: '>=18' }
 
@@ -3642,10 +3643,10 @@ packages:
                 integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==,
             }
 
-    undici-types@7.10.0:
+    undici-types@7.16.0:
         resolution:
             {
-                integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==,
+                integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
             }
 
     unified@11.0.5:
@@ -3846,21 +3847,21 @@ packages:
             yaml:
                 optional: true
 
-    vitefu@1.1.1:
+    vitefu@1.1.2:
         resolution:
             {
-                integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==,
+                integrity: sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==,
             }
         peerDependencies:
-            vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+            vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
         peerDependenciesMeta:
             vite:
                 optional: true
 
-    volar-service-css@0.0.68:
+    volar-service-css@0.0.70:
         resolution:
             {
-                integrity: sha512-lJSMh6f3QzZ1tdLOZOzovLX0xzAadPhx8EKwraDLPxBndLCYfoTvnNuiFFV8FARrpAlW5C0WkH+TstPaCxr00Q==,
+                integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==,
             }
         peerDependencies:
             '@volar/language-service': ~2.4.0
@@ -3868,10 +3869,10 @@ packages:
             '@volar/language-service':
                 optional: true
 
-    volar-service-emmet@0.0.68:
+    volar-service-emmet@0.0.70:
         resolution:
             {
-                integrity: sha512-nHvixrRQ83EzkQ4G/jFxu9Y4eSsXS/X2cltEPDM+K9qZmIv+Ey1w0tg1+6caSe8TU5Hgw4oSTwNMf/6cQb3LzQ==,
+                integrity: sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==,
             }
         peerDependencies:
             '@volar/language-service': ~2.4.0
@@ -3879,10 +3880,10 @@ packages:
             '@volar/language-service':
                 optional: true
 
-    volar-service-html@0.0.68:
+    volar-service-html@0.0.70:
         resolution:
             {
-                integrity: sha512-fru9gsLJxy33xAltXOh4TEdi312HP80hpuKhpYQD4O5hDnkNPEBdcQkpB+gcX0oK0VxRv1UOzcGQEUzWCVHLfA==,
+                integrity: sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==,
             }
         peerDependencies:
             '@volar/language-service': ~2.4.0
@@ -3890,10 +3891,10 @@ packages:
             '@volar/language-service':
                 optional: true
 
-    volar-service-prettier@0.0.68:
+    volar-service-prettier@0.0.70:
         resolution:
             {
-                integrity: sha512-grUmWHkHlebMOd6V8vXs2eNQUw/bJGJMjekh/EPf/p2ZNTK0Uyz7hoBRngcvGfJHMsSXZH8w/dZTForIW/4ihw==,
+                integrity: sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==,
             }
         peerDependencies:
             '@volar/language-service': ~2.4.0
@@ -3904,10 +3905,10 @@ packages:
             prettier:
                 optional: true
 
-    volar-service-typescript-twoslash-queries@0.0.68:
+    volar-service-typescript-twoslash-queries@0.0.70:
         resolution:
             {
-                integrity: sha512-NugzXcM0iwuZFLCJg47vI93su5YhTIweQuLmZxvz5ZPTaman16JCvmDZexx2rd5T/75SNuvvZmrTOTNYUsfe5w==,
+                integrity: sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==,
             }
         peerDependencies:
             '@volar/language-service': ~2.4.0
@@ -3915,10 +3916,10 @@ packages:
             '@volar/language-service':
                 optional: true
 
-    volar-service-typescript@0.0.68:
+    volar-service-typescript@0.0.70:
         resolution:
             {
-                integrity: sha512-z7B/7CnJ0+TWWFp/gh2r5/QwMObHNDiQiv4C9pTBNI2Wxuwymd4bjEORzrJ/hJ5Yd5+OzeYK+nFCKevoGEEeKw==,
+                integrity: sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==,
             }
         peerDependencies:
             '@volar/language-service': ~2.4.0
@@ -3926,10 +3927,10 @@ packages:
             '@volar/language-service':
                 optional: true
 
-    volar-service-yaml@0.0.68:
+    volar-service-yaml@0.0.70:
         resolution:
             {
-                integrity: sha512-84XgE02LV0OvTcwfqhcSwVg4of3MLNUWPMArO6Aj8YXqyEVnPu8xTEMY2btKSq37mVAPuaEVASI4e3ptObmqcA==,
+                integrity: sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==,
             }
         peerDependencies:
             '@volar/language-service': ~2.4.0
@@ -3937,16 +3938,16 @@ packages:
             '@volar/language-service':
                 optional: true
 
-    vscode-css-languageservice@6.3.9:
+    vscode-css-languageservice@6.3.10:
         resolution:
             {
-                integrity: sha512-1tLWfp+TDM5ZuVWht3jmaY5y7O6aZmpeXLoHl5bv1QtRsRKt4xYGRMmdJa5Pqx/FTkgRbsna9R+Gn2xE+evVuA==,
+                integrity: sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==,
             }
 
-    vscode-html-languageservice@5.6.1:
+    vscode-html-languageservice@5.6.2:
         resolution:
             {
-                integrity: sha512-5Mrqy5CLfFZUgkyhNZLA1Ye5g12Cb/v6VM7SxUzZUaRKWMDz4md+y26PrfRTSU0/eQAl3XpO9m2og+GGtDMuaA==,
+                integrity: sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==,
             }
 
     vscode-json-languageservice@4.1.8:
@@ -4047,10 +4048,10 @@ packages:
             }
         engines: { node: '>=10' }
 
-    yaml-language-server@1.19.2:
+    yaml-language-server@1.20.0:
         resolution:
             {
-                integrity: sha512-9F3myNmJzUN/679jycdMxqtydPSDRAarSj3wPiF7pchEPnO9Dg07Oc+gIYLqXR4L+g+FSEVXXv2+mr54StLFOg==,
+                integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==,
             }
         hasBin: true
 
@@ -4128,6 +4129,12 @@ packages:
                 integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
             }
 
+    zod@4.3.6:
+        resolution:
+            {
+                integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
+            }
+
     zwitch@2.0.4:
         resolution:
             {
@@ -4135,9 +4142,9 @@ packages:
             }
 
 snapshots:
-    '@astrojs/check@0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
+    '@astrojs/check@0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
         dependencies:
-            '@astrojs/language-server': 2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
+            '@astrojs/language-server': 2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
             chokidar: 4.0.3
             kleur: 4.1.5
             typescript: 5.9.3
@@ -4148,12 +4155,12 @@ snapshots:
 
     '@astrojs/compiler@2.13.1': {}
 
-    '@astrojs/internal-helpers@0.7.5': {}
+    '@astrojs/internal-helpers@0.7.6': {}
 
-    '@astrojs/language-server@2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
+    '@astrojs/language-server@2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
         dependencies:
             '@astrojs/compiler': 2.13.1
-            '@astrojs/yaml2ts': 0.2.2
+            '@astrojs/yaml2ts': 0.2.3
             '@jridgewell/sourcemap-codec': 1.5.5
             '@volar/kit': 2.4.28(typescript@5.9.3)
             '@volar/language-core': 2.4.28
@@ -4161,14 +4168,14 @@ snapshots:
             '@volar/language-service': 2.4.28
             muggle-string: 0.4.1
             tinyglobby: 0.2.15
-            volar-service-css: 0.0.68(@volar/language-service@2.4.28)
-            volar-service-emmet: 0.0.68(@volar/language-service@2.4.28)
-            volar-service-html: 0.0.68(@volar/language-service@2.4.28)
-            volar-service-prettier: 0.0.68(@volar/language-service@2.4.28)(prettier@3.5.3)
-            volar-service-typescript: 0.0.68(@volar/language-service@2.4.28)
-            volar-service-typescript-twoslash-queries: 0.0.68(@volar/language-service@2.4.28)
-            volar-service-yaml: 0.0.68(@volar/language-service@2.4.28)
-            vscode-html-languageservice: 5.6.1
+            volar-service-css: 0.0.70(@volar/language-service@2.4.28)
+            volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
+            volar-service-html: 0.0.70(@volar/language-service@2.4.28)
+            volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.5.3)
+            volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
+            volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
+            volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
+            vscode-html-languageservice: 5.6.2
             vscode-uri: 3.1.0
         optionalDependencies:
             prettier: 3.5.3
@@ -4176,9 +4183,9 @@ snapshots:
         transitivePeerDependencies:
             - typescript
 
-    '@astrojs/markdown-remark@6.3.10':
+    '@astrojs/markdown-remark@6.3.11':
         dependencies:
-            '@astrojs/internal-helpers': 0.7.5
+            '@astrojs/internal-helpers': 0.7.6
             '@astrojs/prism': 3.3.0
             github-slugger: 2.0.0
             hast-util-from-html: 2.0.3
@@ -4192,7 +4199,7 @@ snapshots:
             remark-parse: 11.0.0
             remark-rehype: 11.1.2
             remark-smartypants: 3.0.2
-            shiki: 3.22.0
+            shiki: 3.23.0
             smol-toml: 1.6.0
             unified: 11.0.5
             unist-util-remove-position: 5.0.0
@@ -4202,12 +4209,12 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@astrojs/mdx@4.3.13(astro@5.17.3(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))':
+    '@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))':
         dependencies:
-            '@astrojs/markdown-remark': 6.3.10
+            '@astrojs/markdown-remark': 6.3.11
             '@mdx-js/mdx': 3.1.1
             acorn: 8.16.0
-            astro: 5.17.3(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
+            astro: 5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
             es-module-lexer: 1.7.0
             estree-util-visit: 2.0.0
             hast-util-to-html: 9.0.5
@@ -4225,16 +4232,17 @@ snapshots:
         dependencies:
             prismjs: 1.30.0
 
-    '@astrojs/rss@4.0.15':
+    '@astrojs/rss@4.0.17':
         dependencies:
-            fast-xml-parser: 5.3.6
+            fast-xml-parser: 5.4.1
             piccolore: 0.1.3
+            zod: 4.3.6
 
-    '@astrojs/sitemap@3.7.0':
+    '@astrojs/sitemap@3.7.1':
         dependencies:
-            sitemap: 8.0.2
+            sitemap: 9.0.1
             stream-replace-string: 2.0.0
-            zod: 3.25.76
+            zod: 4.3.6
 
     '@astrojs/telemetry@3.3.0':
         dependencies:
@@ -4248,7 +4256,7 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@astrojs/yaml2ts@0.2.2':
+    '@astrojs/yaml2ts@0.2.3':
         dependencies:
             yaml: 2.8.2
 
@@ -4256,7 +4264,7 @@ snapshots:
 
     '@babel/helper-validator-identifier@7.28.5': {}
 
-    '@babel/parser@7.29.0':
+    '@babel/parser@7.29.2':
         dependencies:
             '@babel/types': 7.29.0
 
@@ -4267,7 +4275,7 @@ snapshots:
 
     '@capsizecss/unpack@4.0.0':
         dependencies:
-            fontkitten: 1.0.2
+            fontkitten: 1.0.3
 
     '@emmetio/abbreviation@2.3.3':
         dependencies:
@@ -4292,7 +4300,7 @@ snapshots:
 
     '@emmetio/stream-reader@2.2.0': {}
 
-    '@emnapi/runtime@1.8.1':
+    '@emnapi/runtime@1.9.1':
         dependencies:
             tslib: 2.8.1
         optional: true
@@ -4300,160 +4308,160 @@ snapshots:
     '@esbuild/aix-ppc64@0.25.12':
         optional: true
 
-    '@esbuild/aix-ppc64@0.27.3':
+    '@esbuild/aix-ppc64@0.27.4':
         optional: true
 
     '@esbuild/android-arm64@0.25.12':
         optional: true
 
-    '@esbuild/android-arm64@0.27.3':
+    '@esbuild/android-arm64@0.27.4':
         optional: true
 
     '@esbuild/android-arm@0.25.12':
         optional: true
 
-    '@esbuild/android-arm@0.27.3':
+    '@esbuild/android-arm@0.27.4':
         optional: true
 
     '@esbuild/android-x64@0.25.12':
         optional: true
 
-    '@esbuild/android-x64@0.27.3':
+    '@esbuild/android-x64@0.27.4':
         optional: true
 
     '@esbuild/darwin-arm64@0.25.12':
         optional: true
 
-    '@esbuild/darwin-arm64@0.27.3':
+    '@esbuild/darwin-arm64@0.27.4':
         optional: true
 
     '@esbuild/darwin-x64@0.25.12':
         optional: true
 
-    '@esbuild/darwin-x64@0.27.3':
+    '@esbuild/darwin-x64@0.27.4':
         optional: true
 
     '@esbuild/freebsd-arm64@0.25.12':
         optional: true
 
-    '@esbuild/freebsd-arm64@0.27.3':
+    '@esbuild/freebsd-arm64@0.27.4':
         optional: true
 
     '@esbuild/freebsd-x64@0.25.12':
         optional: true
 
-    '@esbuild/freebsd-x64@0.27.3':
+    '@esbuild/freebsd-x64@0.27.4':
         optional: true
 
     '@esbuild/linux-arm64@0.25.12':
         optional: true
 
-    '@esbuild/linux-arm64@0.27.3':
+    '@esbuild/linux-arm64@0.27.4':
         optional: true
 
     '@esbuild/linux-arm@0.25.12':
         optional: true
 
-    '@esbuild/linux-arm@0.27.3':
+    '@esbuild/linux-arm@0.27.4':
         optional: true
 
     '@esbuild/linux-ia32@0.25.12':
         optional: true
 
-    '@esbuild/linux-ia32@0.27.3':
+    '@esbuild/linux-ia32@0.27.4':
         optional: true
 
     '@esbuild/linux-loong64@0.25.12':
         optional: true
 
-    '@esbuild/linux-loong64@0.27.3':
+    '@esbuild/linux-loong64@0.27.4':
         optional: true
 
     '@esbuild/linux-mips64el@0.25.12':
         optional: true
 
-    '@esbuild/linux-mips64el@0.27.3':
+    '@esbuild/linux-mips64el@0.27.4':
         optional: true
 
     '@esbuild/linux-ppc64@0.25.12':
         optional: true
 
-    '@esbuild/linux-ppc64@0.27.3':
+    '@esbuild/linux-ppc64@0.27.4':
         optional: true
 
     '@esbuild/linux-riscv64@0.25.12':
         optional: true
 
-    '@esbuild/linux-riscv64@0.27.3':
+    '@esbuild/linux-riscv64@0.27.4':
         optional: true
 
     '@esbuild/linux-s390x@0.25.12':
         optional: true
 
-    '@esbuild/linux-s390x@0.27.3':
+    '@esbuild/linux-s390x@0.27.4':
         optional: true
 
     '@esbuild/linux-x64@0.25.12':
         optional: true
 
-    '@esbuild/linux-x64@0.27.3':
+    '@esbuild/linux-x64@0.27.4':
         optional: true
 
     '@esbuild/netbsd-arm64@0.25.12':
         optional: true
 
-    '@esbuild/netbsd-arm64@0.27.3':
+    '@esbuild/netbsd-arm64@0.27.4':
         optional: true
 
     '@esbuild/netbsd-x64@0.25.12':
         optional: true
 
-    '@esbuild/netbsd-x64@0.27.3':
+    '@esbuild/netbsd-x64@0.27.4':
         optional: true
 
     '@esbuild/openbsd-arm64@0.25.12':
         optional: true
 
-    '@esbuild/openbsd-arm64@0.27.3':
+    '@esbuild/openbsd-arm64@0.27.4':
         optional: true
 
     '@esbuild/openbsd-x64@0.25.12':
         optional: true
 
-    '@esbuild/openbsd-x64@0.27.3':
+    '@esbuild/openbsd-x64@0.27.4':
         optional: true
 
     '@esbuild/openharmony-arm64@0.25.12':
         optional: true
 
-    '@esbuild/openharmony-arm64@0.27.3':
+    '@esbuild/openharmony-arm64@0.27.4':
         optional: true
 
     '@esbuild/sunos-x64@0.25.12':
         optional: true
 
-    '@esbuild/sunos-x64@0.27.3':
+    '@esbuild/sunos-x64@0.27.4':
         optional: true
 
     '@esbuild/win32-arm64@0.25.12':
         optional: true
 
-    '@esbuild/win32-arm64@0.27.3':
+    '@esbuild/win32-arm64@0.27.4':
         optional: true
 
     '@esbuild/win32-ia32@0.25.12':
         optional: true
 
-    '@esbuild/win32-ia32@0.27.3':
+    '@esbuild/win32-ia32@0.27.4':
         optional: true
 
     '@esbuild/win32-x64@0.25.12':
         optional: true
 
-    '@esbuild/win32-x64@0.27.3':
+    '@esbuild/win32-x64@0.27.4':
         optional: true
 
-    '@img/colour@1.0.0': {}
+    '@img/colour@1.1.0': {}
 
     '@img/sharp-darwin-arm64@0.34.5':
         optionalDependencies:
@@ -4537,7 +4545,7 @@ snapshots:
 
     '@img/sharp-wasm32@0.34.5':
         dependencies:
-            '@emnapi/runtime': 1.8.1
+            '@emnapi/runtime': 1.9.1
         optional: true
 
     '@img/sharp-win32-arm64@0.34.5':
@@ -4602,191 +4610,191 @@ snapshots:
 
     '@pkgr/core@0.2.9': {}
 
-    '@rollup/pluginutils@5.3.0(rollup@4.57.1)':
+    '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
         dependencies:
             '@types/estree': 1.0.8
             estree-walker: 2.0.2
             picomatch: 4.0.3
         optionalDependencies:
-            rollup: 4.57.1
+            rollup: 4.59.0
 
-    '@rollup/rollup-android-arm-eabi@4.57.1':
+    '@rollup/rollup-android-arm-eabi@4.59.0':
         optional: true
 
-    '@rollup/rollup-android-arm64@4.57.1':
+    '@rollup/rollup-android-arm64@4.59.0':
         optional: true
 
-    '@rollup/rollup-darwin-arm64@4.57.1':
+    '@rollup/rollup-darwin-arm64@4.59.0':
         optional: true
 
-    '@rollup/rollup-darwin-x64@4.57.1':
+    '@rollup/rollup-darwin-x64@4.59.0':
         optional: true
 
-    '@rollup/rollup-freebsd-arm64@4.57.1':
+    '@rollup/rollup-freebsd-arm64@4.59.0':
         optional: true
 
-    '@rollup/rollup-freebsd-x64@4.57.1':
+    '@rollup/rollup-freebsd-x64@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    '@rollup/rollup-linux-arm-musleabihf@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    '@rollup/rollup-linux-arm64-gnu@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-arm64-musl@4.57.1':
+    '@rollup/rollup-linux-arm64-musl@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    '@rollup/rollup-linux-loong64-gnu@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-loong64-musl@4.57.1':
+    '@rollup/rollup-linux-loong64-musl@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    '@rollup/rollup-linux-ppc64-gnu@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    '@rollup/rollup-linux-ppc64-musl@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    '@rollup/rollup-linux-riscv64-gnu@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    '@rollup/rollup-linux-riscv64-musl@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    '@rollup/rollup-linux-s390x-gnu@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-x64-gnu@4.57.1':
+    '@rollup/rollup-linux-x64-gnu@4.59.0':
         optional: true
 
-    '@rollup/rollup-linux-x64-musl@4.57.1':
+    '@rollup/rollup-linux-x64-musl@4.59.0':
         optional: true
 
-    '@rollup/rollup-openbsd-x64@4.57.1':
+    '@rollup/rollup-openbsd-x64@4.59.0':
         optional: true
 
-    '@rollup/rollup-openharmony-arm64@4.57.1':
+    '@rollup/rollup-openharmony-arm64@4.59.0':
         optional: true
 
-    '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    '@rollup/rollup-win32-arm64-msvc@4.59.0':
         optional: true
 
-    '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    '@rollup/rollup-win32-ia32-msvc@4.59.0':
         optional: true
 
-    '@rollup/rollup-win32-x64-gnu@4.57.1':
+    '@rollup/rollup-win32-x64-gnu@4.59.0':
         optional: true
 
-    '@rollup/rollup-win32-x64-msvc@4.57.1':
+    '@rollup/rollup-win32-x64-msvc@4.59.0':
         optional: true
 
-    '@shikijs/core@3.22.0':
+    '@shikijs/core@3.23.0':
         dependencies:
-            '@shikijs/types': 3.22.0
+            '@shikijs/types': 3.23.0
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
             hast-util-to-html: 9.0.5
 
-    '@shikijs/engine-javascript@3.22.0':
+    '@shikijs/engine-javascript@3.23.0':
         dependencies:
-            '@shikijs/types': 3.22.0
+            '@shikijs/types': 3.23.0
             '@shikijs/vscode-textmate': 10.0.2
-            oniguruma-to-es: 4.3.4
+            oniguruma-to-es: 4.3.5
 
-    '@shikijs/engine-oniguruma@3.22.0':
+    '@shikijs/engine-oniguruma@3.23.0':
         dependencies:
-            '@shikijs/types': 3.22.0
+            '@shikijs/types': 3.23.0
             '@shikijs/vscode-textmate': 10.0.2
 
-    '@shikijs/langs@3.22.0':
+    '@shikijs/langs@3.23.0':
         dependencies:
-            '@shikijs/types': 3.22.0
+            '@shikijs/types': 3.23.0
 
-    '@shikijs/themes@3.22.0':
+    '@shikijs/themes@3.23.0':
         dependencies:
-            '@shikijs/types': 3.22.0
+            '@shikijs/types': 3.23.0
 
-    '@shikijs/types@3.22.0':
+    '@shikijs/types@3.23.0':
         dependencies:
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
 
     '@shikijs/vscode-textmate@10.0.2': {}
 
-    '@tailwindcss/node@4.2.0':
+    '@tailwindcss/node@4.2.2':
         dependencies:
             '@jridgewell/remapping': 2.3.5
-            enhanced-resolve: 5.19.0
+            enhanced-resolve: 5.20.1
             jiti: 2.6.1
-            lightningcss: 1.31.1
+            lightningcss: 1.32.0
             magic-string: 0.30.21
             source-map-js: 1.2.1
-            tailwindcss: 4.2.0
+            tailwindcss: 4.2.2
 
-    '@tailwindcss/oxide-android-arm64@4.2.0':
+    '@tailwindcss/oxide-android-arm64@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-darwin-arm64@4.2.0':
+    '@tailwindcss/oxide-darwin-arm64@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-darwin-x64@4.2.0':
+    '@tailwindcss/oxide-darwin-x64@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-freebsd-x64@4.2.0':
+    '@tailwindcss/oxide-freebsd-x64@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.0':
+    '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-linux-arm64-gnu@4.2.0':
+    '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
+    '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
+    '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-linux-x64-musl@4.2.0':
+    '@tailwindcss/oxide-linux-x64-musl@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-wasm32-wasi@4.2.0':
+    '@tailwindcss/oxide-wasm32-wasi@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-win32-arm64-msvc@4.2.0':
+    '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide-win32-x64-msvc@4.2.0':
+    '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
         optional: true
 
-    '@tailwindcss/oxide@4.2.0':
+    '@tailwindcss/oxide@4.2.2':
         optionalDependencies:
-            '@tailwindcss/oxide-android-arm64': 4.2.0
-            '@tailwindcss/oxide-darwin-arm64': 4.2.0
-            '@tailwindcss/oxide-darwin-x64': 4.2.0
-            '@tailwindcss/oxide-freebsd-x64': 4.2.0
-            '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.0
-            '@tailwindcss/oxide-linux-arm64-gnu': 4.2.0
-            '@tailwindcss/oxide-linux-arm64-musl': 4.2.0
-            '@tailwindcss/oxide-linux-x64-gnu': 4.2.0
-            '@tailwindcss/oxide-linux-x64-musl': 4.2.0
-            '@tailwindcss/oxide-wasm32-wasi': 4.2.0
-            '@tailwindcss/oxide-win32-arm64-msvc': 4.2.0
-            '@tailwindcss/oxide-win32-x64-msvc': 4.2.0
+            '@tailwindcss/oxide-android-arm64': 4.2.2
+            '@tailwindcss/oxide-darwin-arm64': 4.2.2
+            '@tailwindcss/oxide-darwin-x64': 4.2.2
+            '@tailwindcss/oxide-freebsd-x64': 4.2.2
+            '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+            '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+            '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+            '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+            '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+            '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+            '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+            '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-    '@tailwindcss/vite@4.2.0(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
+    '@tailwindcss/vite@4.2.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
         dependencies:
-            '@tailwindcss/node': 4.2.0
-            '@tailwindcss/oxide': 4.2.0
-            tailwindcss: 4.2.0
-            vite: 6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+            '@tailwindcss/node': 4.2.2
+            '@tailwindcss/oxide': 4.2.2
+            tailwindcss: 4.2.2
+            vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
 
-    '@types/debug@4.1.12':
+    '@types/debug@4.1.13':
         dependencies:
             '@types/ms': 2.1.0
 
@@ -4812,16 +4820,13 @@ snapshots:
         dependencies:
             '@types/unist': 3.0.3
 
-    '@types/node@17.0.45': {}
-
-    '@types/node@24.3.0':
+    '@types/node@24.12.0':
         dependencies:
-            undici-types: 7.10.0
-        optional: true
+            undici-types: 7.16.0
 
     '@types/sax@1.2.7':
         dependencies:
-            '@types/node': 17.0.45
+            '@types/node': 24.12.0
 
     '@types/unist@2.0.11': {}
 
@@ -4925,15 +4930,15 @@ snapshots:
 
     astring@1.9.0: {}
 
-    astro@5.17.3(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2):
+    astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2):
         dependencies:
             '@astrojs/compiler': 2.13.1
-            '@astrojs/internal-helpers': 0.7.5
-            '@astrojs/markdown-remark': 6.3.10
+            '@astrojs/internal-helpers': 0.7.6
+            '@astrojs/markdown-remark': 6.3.11
             '@astrojs/telemetry': 3.3.0
             '@capsizecss/unpack': 4.0.0
             '@oslojs/encoding': 1.1.0
-            '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
+            '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
             acorn: 8.16.0
             aria-query: 5.3.2
             axobject-query: 4.1.0
@@ -4945,12 +4950,12 @@ snapshots:
             cssesc: 3.0.0
             debug: 4.4.3
             deterministic-object-hash: 2.0.2
-            devalue: 5.6.3
+            devalue: 5.6.4
             diff: 8.0.3
             dlv: 1.1.3
             dset: 3.1.4
             es-module-lexer: 1.7.0
-            esbuild: 0.27.3
+            esbuild: 0.27.4
             estree-walker: 3.0.3
             flattie: 1.1.1
             fontace: 0.4.1
@@ -4971,10 +4976,10 @@ snapshots:
             prompts: 2.4.2
             rehype: 13.0.2
             semver: 7.7.4
-            shiki: 3.22.0
+            shiki: 3.23.0
             smol-toml: 1.6.0
-            svgo: 4.0.0
-            tinyexec: 1.0.2
+            svgo: 4.0.1
+            tinyexec: 1.0.4
             tinyglobby: 0.2.15
             tsconfck: 3.1.6(typescript@5.9.3)
             ultrahtml: 1.6.0
@@ -4982,8 +4987,8 @@ snapshots:
             unist-util-visit: 5.1.0
             unstorage: 1.17.4
             vfile: 6.0.3
-            vite: 6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
-            vitefu: 1.1.1(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+            vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+            vitefu: 1.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
             xxhash-wasm: 1.1.0
             yargs-parser: 21.1.1
             yocto-spinner: 0.2.3
@@ -5115,9 +5120,9 @@ snapshots:
             mdn-data: 2.0.28
             source-map-js: 1.2.1
 
-    css-tree@3.1.0:
+    css-tree@3.2.1:
         dependencies:
-            mdn-data: 2.12.2
+            mdn-data: 2.27.1
             source-map-js: 1.2.1
 
     css-what@6.2.2: {}
@@ -5148,7 +5153,7 @@ snapshots:
         dependencies:
             base-64: 1.0.0
 
-    devalue@5.6.3: {}
+    devalue@5.6.4: {}
 
     devlop@1.1.0:
         dependencies:
@@ -5187,7 +5192,7 @@ snapshots:
 
     emoji-regex@8.0.0: {}
 
-    enhanced-resolve@5.19.0:
+    enhanced-resolve@5.20.1:
         dependencies:
             graceful-fs: 4.2.11
             tapable: 2.3.0
@@ -5241,34 +5246,34 @@ snapshots:
             '@esbuild/win32-ia32': 0.25.12
             '@esbuild/win32-x64': 0.25.12
 
-    esbuild@0.27.3:
+    esbuild@0.27.4:
         optionalDependencies:
-            '@esbuild/aix-ppc64': 0.27.3
-            '@esbuild/android-arm': 0.27.3
-            '@esbuild/android-arm64': 0.27.3
-            '@esbuild/android-x64': 0.27.3
-            '@esbuild/darwin-arm64': 0.27.3
-            '@esbuild/darwin-x64': 0.27.3
-            '@esbuild/freebsd-arm64': 0.27.3
-            '@esbuild/freebsd-x64': 0.27.3
-            '@esbuild/linux-arm': 0.27.3
-            '@esbuild/linux-arm64': 0.27.3
-            '@esbuild/linux-ia32': 0.27.3
-            '@esbuild/linux-loong64': 0.27.3
-            '@esbuild/linux-mips64el': 0.27.3
-            '@esbuild/linux-ppc64': 0.27.3
-            '@esbuild/linux-riscv64': 0.27.3
-            '@esbuild/linux-s390x': 0.27.3
-            '@esbuild/linux-x64': 0.27.3
-            '@esbuild/netbsd-arm64': 0.27.3
-            '@esbuild/netbsd-x64': 0.27.3
-            '@esbuild/openbsd-arm64': 0.27.3
-            '@esbuild/openbsd-x64': 0.27.3
-            '@esbuild/openharmony-arm64': 0.27.3
-            '@esbuild/sunos-x64': 0.27.3
-            '@esbuild/win32-arm64': 0.27.3
-            '@esbuild/win32-ia32': 0.27.3
-            '@esbuild/win32-x64': 0.27.3
+            '@esbuild/aix-ppc64': 0.27.4
+            '@esbuild/android-arm': 0.27.4
+            '@esbuild/android-arm64': 0.27.4
+            '@esbuild/android-x64': 0.27.4
+            '@esbuild/darwin-arm64': 0.27.4
+            '@esbuild/darwin-x64': 0.27.4
+            '@esbuild/freebsd-arm64': 0.27.4
+            '@esbuild/freebsd-x64': 0.27.4
+            '@esbuild/linux-arm': 0.27.4
+            '@esbuild/linux-arm64': 0.27.4
+            '@esbuild/linux-ia32': 0.27.4
+            '@esbuild/linux-loong64': 0.27.4
+            '@esbuild/linux-mips64el': 0.27.4
+            '@esbuild/linux-ppc64': 0.27.4
+            '@esbuild/linux-riscv64': 0.27.4
+            '@esbuild/linux-s390x': 0.27.4
+            '@esbuild/linux-x64': 0.27.4
+            '@esbuild/netbsd-arm64': 0.27.4
+            '@esbuild/netbsd-x64': 0.27.4
+            '@esbuild/openbsd-arm64': 0.27.4
+            '@esbuild/openbsd-x64': 0.27.4
+            '@esbuild/openharmony-arm64': 0.27.4
+            '@esbuild/sunos-x64': 0.27.4
+            '@esbuild/win32-arm64': 0.27.4
+            '@esbuild/win32-ia32': 0.27.4
+            '@esbuild/win32-x64': 0.27.4
 
     escalade@3.2.0: {}
 
@@ -5317,9 +5322,14 @@ snapshots:
 
     fast-uri@3.1.0: {}
 
-    fast-xml-parser@5.3.6:
+    fast-xml-builder@1.1.4:
         dependencies:
-            strnum: 2.1.2
+            path-expression-matcher: 1.2.0
+
+    fast-xml-parser@5.4.1:
+        dependencies:
+            fast-xml-builder: 1.1.4
+            strnum: 2.2.1
 
     fdir@6.5.0(picomatch@4.0.3):
         optionalDependencies:
@@ -5329,9 +5339,9 @@ snapshots:
 
     fontace@0.4.1:
         dependencies:
-            fontkitten: 1.0.2
+            fontkitten: 1.0.3
 
-    fontkitten@1.0.2:
+    fontkitten@1.0.3:
         dependencies:
             tiny-inflate: 1.0.3
 
@@ -5346,7 +5356,7 @@ snapshots:
 
     graceful-fs@4.2.11: {}
 
-    h3@1.15.5:
+    h3@1.15.9:
         dependencies:
             cookie-es: 1.2.2
             crossws: 0.3.5
@@ -5541,60 +5551,58 @@ snapshots:
 
     kleur@4.1.5: {}
 
-    lightningcss-android-arm64@1.31.1:
+    lightningcss-android-arm64@1.32.0:
         optional: true
 
-    lightningcss-darwin-arm64@1.31.1:
+    lightningcss-darwin-arm64@1.32.0:
         optional: true
 
-    lightningcss-darwin-x64@1.31.1:
+    lightningcss-darwin-x64@1.32.0:
         optional: true
 
-    lightningcss-freebsd-x64@1.31.1:
+    lightningcss-freebsd-x64@1.32.0:
         optional: true
 
-    lightningcss-linux-arm-gnueabihf@1.31.1:
+    lightningcss-linux-arm-gnueabihf@1.32.0:
         optional: true
 
-    lightningcss-linux-arm64-gnu@1.31.1:
+    lightningcss-linux-arm64-gnu@1.32.0:
         optional: true
 
-    lightningcss-linux-arm64-musl@1.31.1:
+    lightningcss-linux-arm64-musl@1.32.0:
         optional: true
 
-    lightningcss-linux-x64-gnu@1.31.1:
+    lightningcss-linux-x64-gnu@1.32.0:
         optional: true
 
-    lightningcss-linux-x64-musl@1.31.1:
+    lightningcss-linux-x64-musl@1.32.0:
         optional: true
 
-    lightningcss-win32-arm64-msvc@1.31.1:
+    lightningcss-win32-arm64-msvc@1.32.0:
         optional: true
 
-    lightningcss-win32-x64-msvc@1.31.1:
+    lightningcss-win32-x64-msvc@1.32.0:
         optional: true
 
-    lightningcss@1.31.1:
+    lightningcss@1.32.0:
         dependencies:
             detect-libc: 2.1.2
         optionalDependencies:
-            lightningcss-android-arm64: 1.31.1
-            lightningcss-darwin-arm64: 1.31.1
-            lightningcss-darwin-x64: 1.31.1
-            lightningcss-freebsd-x64: 1.31.1
-            lightningcss-linux-arm-gnueabihf: 1.31.1
-            lightningcss-linux-arm64-gnu: 1.31.1
-            lightningcss-linux-arm64-musl: 1.31.1
-            lightningcss-linux-x64-gnu: 1.31.1
-            lightningcss-linux-x64-musl: 1.31.1
-            lightningcss-win32-arm64-msvc: 1.31.1
-            lightningcss-win32-x64-msvc: 1.31.1
-
-    lodash@4.17.21: {}
+            lightningcss-android-arm64: 1.32.0
+            lightningcss-darwin-arm64: 1.32.0
+            lightningcss-darwin-x64: 1.32.0
+            lightningcss-freebsd-x64: 1.32.0
+            lightningcss-linux-arm-gnueabihf: 1.32.0
+            lightningcss-linux-arm64-gnu: 1.32.0
+            lightningcss-linux-arm64-musl: 1.32.0
+            lightningcss-linux-x64-gnu: 1.32.0
+            lightningcss-linux-x64-musl: 1.32.0
+            lightningcss-win32-arm64-msvc: 1.32.0
+            lightningcss-win32-x64-msvc: 1.32.0
 
     longest-streak@3.1.0: {}
 
-    lru-cache@11.2.6: {}
+    lru-cache@11.2.7: {}
 
     magic-string@0.30.21:
         dependencies:
@@ -5602,7 +5610,7 @@ snapshots:
 
     magicast@0.5.2:
         dependencies:
-            '@babel/parser': 7.29.0
+            '@babel/parser': 7.29.2
             '@babel/types': 7.29.0
             source-map-js: 1.2.1
 
@@ -5623,7 +5631,7 @@ snapshots:
             unist-util-is: 6.0.1
             unist-util-visit-parents: 6.0.2
 
-    mdast-util-from-markdown@2.0.2:
+    mdast-util-from-markdown@2.0.3:
         dependencies:
             '@types/mdast': 4.0.4
             '@types/unist': 3.0.3
@@ -5652,7 +5660,7 @@ snapshots:
         dependencies:
             '@types/mdast': 4.0.4
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
             micromark-util-normalize-identifier: 2.0.1
         transitivePeerDependencies:
@@ -5661,7 +5669,7 @@ snapshots:
     mdast-util-gfm-strikethrough@2.0.0:
         dependencies:
             '@types/mdast': 4.0.4
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
@@ -5671,7 +5679,7 @@ snapshots:
             '@types/mdast': 4.0.4
             devlop: 1.1.0
             markdown-table: 3.0.4
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
@@ -5680,14 +5688,14 @@ snapshots:
         dependencies:
             '@types/mdast': 4.0.4
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
 
     mdast-util-gfm@3.1.0:
         dependencies:
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-gfm-autolink-literal: 2.0.1
             mdast-util-gfm-footnote: 2.1.0
             mdast-util-gfm-strikethrough: 2.0.0
@@ -5703,7 +5711,7 @@ snapshots:
             '@types/hast': 3.0.4
             '@types/mdast': 4.0.4
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
@@ -5716,7 +5724,7 @@ snapshots:
             '@types/unist': 3.0.3
             ccount: 2.0.1
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
             parse-entities: 4.0.2
             stringify-entities: 4.0.4
@@ -5727,7 +5735,7 @@ snapshots:
 
     mdast-util-mdx@3.0.0:
         dependencies:
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-mdx-expression: 2.0.1
             mdast-util-mdx-jsx: 3.2.0
             mdast-util-mdxjs-esm: 2.0.1
@@ -5741,7 +5749,7 @@ snapshots:
             '@types/hast': 3.0.4
             '@types/mdast': 4.0.4
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
@@ -5781,7 +5789,7 @@ snapshots:
 
     mdn-data@2.0.28: {}
 
-    mdn-data@2.12.2: {}
+    mdn-data@2.27.1: {}
 
     micromark-core-commonmark@2.0.3:
         dependencies:
@@ -6027,7 +6035,7 @@ snapshots:
 
     micromark@4.0.2:
         dependencies:
-            '@types/debug': 4.1.12
+            '@types/debug': 4.1.13
             debug: 4.4.3
             decode-named-character-reference: 1.3.0
             devlop: 1.1.0
@@ -6083,7 +6091,7 @@ snapshots:
 
     oniguruma-parser@0.12.1: {}
 
-    oniguruma-to-es@4.3.4:
+    oniguruma-to-es@4.3.5:
         dependencies:
             oniguruma-parser: 0.12.1
             regex: 6.1.0
@@ -6127,6 +6135,8 @@ snapshots:
 
     path-browserify@1.0.1: {}
 
+    path-expression-matcher@1.2.0: {}
+
     piccolore@0.1.3: {}
 
     picocolors@1.1.1: {}
@@ -6135,7 +6145,7 @@ snapshots:
 
     picomatch@4.0.3: {}
 
-    postcss@8.5.6:
+    postcss@8.5.8:
         dependencies:
             nanoid: 3.3.11
             picocolors: 1.1.1
@@ -6274,7 +6284,7 @@ snapshots:
     remark-parse@11.0.0:
         dependencies:
             '@types/mdast': 4.0.4
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             micromark-util-types: 2.0.2
             unified: 11.0.5
         transitivePeerDependencies:
@@ -6334,35 +6344,35 @@ snapshots:
             retext-stringify: 4.0.0
             unified: 11.0.5
 
-    rollup@4.57.1:
+    rollup@4.59.0:
         dependencies:
             '@types/estree': 1.0.8
         optionalDependencies:
-            '@rollup/rollup-android-arm-eabi': 4.57.1
-            '@rollup/rollup-android-arm64': 4.57.1
-            '@rollup/rollup-darwin-arm64': 4.57.1
-            '@rollup/rollup-darwin-x64': 4.57.1
-            '@rollup/rollup-freebsd-arm64': 4.57.1
-            '@rollup/rollup-freebsd-x64': 4.57.1
-            '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
-            '@rollup/rollup-linux-arm-musleabihf': 4.57.1
-            '@rollup/rollup-linux-arm64-gnu': 4.57.1
-            '@rollup/rollup-linux-arm64-musl': 4.57.1
-            '@rollup/rollup-linux-loong64-gnu': 4.57.1
-            '@rollup/rollup-linux-loong64-musl': 4.57.1
-            '@rollup/rollup-linux-ppc64-gnu': 4.57.1
-            '@rollup/rollup-linux-ppc64-musl': 4.57.1
-            '@rollup/rollup-linux-riscv64-gnu': 4.57.1
-            '@rollup/rollup-linux-riscv64-musl': 4.57.1
-            '@rollup/rollup-linux-s390x-gnu': 4.57.1
-            '@rollup/rollup-linux-x64-gnu': 4.57.1
-            '@rollup/rollup-linux-x64-musl': 4.57.1
-            '@rollup/rollup-openbsd-x64': 4.57.1
-            '@rollup/rollup-openharmony-arm64': 4.57.1
-            '@rollup/rollup-win32-arm64-msvc': 4.57.1
-            '@rollup/rollup-win32-ia32-msvc': 4.57.1
-            '@rollup/rollup-win32-x64-gnu': 4.57.1
-            '@rollup/rollup-win32-x64-msvc': 4.57.1
+            '@rollup/rollup-android-arm-eabi': 4.59.0
+            '@rollup/rollup-android-arm64': 4.59.0
+            '@rollup/rollup-darwin-arm64': 4.59.0
+            '@rollup/rollup-darwin-x64': 4.59.0
+            '@rollup/rollup-freebsd-arm64': 4.59.0
+            '@rollup/rollup-freebsd-x64': 4.59.0
+            '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+            '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+            '@rollup/rollup-linux-arm64-gnu': 4.59.0
+            '@rollup/rollup-linux-arm64-musl': 4.59.0
+            '@rollup/rollup-linux-loong64-gnu': 4.59.0
+            '@rollup/rollup-linux-loong64-musl': 4.59.0
+            '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+            '@rollup/rollup-linux-ppc64-musl': 4.59.0
+            '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+            '@rollup/rollup-linux-riscv64-musl': 4.59.0
+            '@rollup/rollup-linux-s390x-gnu': 4.59.0
+            '@rollup/rollup-linux-x64-gnu': 4.59.0
+            '@rollup/rollup-linux-x64-musl': 4.59.0
+            '@rollup/rollup-openbsd-x64': 4.59.0
+            '@rollup/rollup-openharmony-arm64': 4.59.0
+            '@rollup/rollup-win32-arm64-msvc': 4.59.0
+            '@rollup/rollup-win32-ia32-msvc': 4.59.0
+            '@rollup/rollup-win32-x64-gnu': 4.59.0
+            '@rollup/rollup-win32-x64-msvc': 4.59.0
             fsevents: 2.3.3
 
     s.color@0.0.15: {}
@@ -6371,13 +6381,13 @@ snapshots:
         dependencies:
             suf-log: 2.5.3
 
-    sax@1.4.4: {}
+    sax@1.6.0: {}
 
     semver@7.7.4: {}
 
     sharp@0.34.5:
         dependencies:
-            '@img/colour': 1.0.0
+            '@img/colour': 1.1.0
             detect-libc: 2.1.2
             semver: 7.7.4
         optionalDependencies:
@@ -6406,14 +6416,14 @@ snapshots:
             '@img/sharp-win32-ia32': 0.34.5
             '@img/sharp-win32-x64': 0.34.5
 
-    shiki@3.22.0:
+    shiki@3.23.0:
         dependencies:
-            '@shikijs/core': 3.22.0
-            '@shikijs/engine-javascript': 3.22.0
-            '@shikijs/engine-oniguruma': 3.22.0
-            '@shikijs/langs': 3.22.0
-            '@shikijs/themes': 3.22.0
-            '@shikijs/types': 3.22.0
+            '@shikijs/core': 3.23.0
+            '@shikijs/engine-javascript': 3.23.0
+            '@shikijs/engine-oniguruma': 3.23.0
+            '@shikijs/langs': 3.23.0
+            '@shikijs/themes': 3.23.0
+            '@shikijs/types': 3.23.0
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
 
@@ -6421,12 +6431,12 @@ snapshots:
 
     sisteransi@1.0.5: {}
 
-    sitemap@8.0.2:
+    sitemap@9.0.1:
         dependencies:
-            '@types/node': 17.0.45
+            '@types/node': 24.12.0
             '@types/sax': 1.2.7
             arg: 5.0.2
-            sax: 1.4.4
+            sax: 1.6.0
 
     smol-toml@1.6.0: {}
 
@@ -6448,7 +6458,7 @@ snapshots:
         dependencies:
             emoji-regex: 10.6.0
             get-east-asian-width: 1.5.0
-            strip-ansi: 7.1.2
+            strip-ansi: 7.2.0
 
     stringify-entities@4.0.4:
         dependencies:
@@ -6459,11 +6469,11 @@ snapshots:
         dependencies:
             ansi-regex: 5.0.1
 
-    strip-ansi@7.1.2:
+    strip-ansi@7.2.0:
         dependencies:
             ansi-regex: 6.2.2
 
-    strnum@2.1.2: {}
+    strnum@2.2.1: {}
 
     style-to-js@1.1.21:
         dependencies:
@@ -6477,17 +6487,17 @@ snapshots:
         dependencies:
             s.color: 0.0.15
 
-    svgo@4.0.0:
+    svgo@4.0.1:
         dependencies:
             commander: 11.1.0
             css-select: 5.2.2
-            css-tree: 3.1.0
+            css-tree: 3.2.1
             css-what: 6.2.2
             csso: 5.0.5
             picocolors: 1.1.1
-            sax: 1.4.4
+            sax: 1.6.0
 
-    tailwindcss@4.2.0: {}
+    tailwindcss@4.2.2: {}
 
     tapable@2.3.0: {}
 
@@ -6495,7 +6505,7 @@ snapshots:
 
     tinyexec@0.3.2: {}
 
-    tinyexec@1.0.2: {}
+    tinyexec@1.0.4: {}
 
     tinyglobby@0.2.15:
         dependencies:
@@ -6528,8 +6538,7 @@ snapshots:
 
     uncrypto@0.1.3: {}
 
-    undici-types@7.10.0:
-        optional: true
+    undici-types@7.16.0: {}
 
     unified@11.0.5:
         dependencies:
@@ -6543,7 +6552,7 @@ snapshots:
 
     unifont@0.7.4:
         dependencies:
-            css-tree: 3.1.0
+            css-tree: 3.2.1
             ofetch: 1.5.1
             ohash: 2.0.11
 
@@ -6598,8 +6607,8 @@ snapshots:
             anymatch: 3.1.3
             chokidar: 5.0.0
             destr: 2.0.5
-            h3: 1.15.5
-            lru-cache: 11.2.6
+            h3: 1.15.9
+            lru-cache: 11.2.7
             node-fetch-native: 1.6.7
             ofetch: 1.5.1
             ufo: 1.6.3
@@ -6619,34 +6628,34 @@ snapshots:
             '@types/unist': 3.0.3
             vfile-message: 4.0.3
 
-    vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
+    vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2):
         dependencies:
             esbuild: 0.25.12
             fdir: 6.5.0(picomatch@4.0.3)
             picomatch: 4.0.3
-            postcss: 8.5.6
-            rollup: 4.57.1
+            postcss: 8.5.8
+            rollup: 4.59.0
             tinyglobby: 0.2.15
         optionalDependencies:
-            '@types/node': 24.3.0
+            '@types/node': 24.12.0
             fsevents: 2.3.3
             jiti: 2.6.1
-            lightningcss: 1.31.1
+            lightningcss: 1.32.0
             yaml: 2.8.2
 
-    vitefu@1.1.1(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)):
+    vitefu@1.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)):
         optionalDependencies:
-            vite: 6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+            vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
 
-    volar-service-css@0.0.68(@volar/language-service@2.4.28):
+    volar-service-css@0.0.70(@volar/language-service@2.4.28):
         dependencies:
-            vscode-css-languageservice: 6.3.9
+            vscode-css-languageservice: 6.3.10
             vscode-languageserver-textdocument: 1.0.12
             vscode-uri: 3.1.0
         optionalDependencies:
             '@volar/language-service': 2.4.28
 
-    volar-service-emmet@0.0.68(@volar/language-service@2.4.28):
+    volar-service-emmet@0.0.70(@volar/language-service@2.4.28):
         dependencies:
             '@emmetio/css-parser': 0.4.1
             '@emmetio/html-matcher': 1.3.0
@@ -6655,28 +6664,28 @@ snapshots:
         optionalDependencies:
             '@volar/language-service': 2.4.28
 
-    volar-service-html@0.0.68(@volar/language-service@2.4.28):
+    volar-service-html@0.0.70(@volar/language-service@2.4.28):
         dependencies:
-            vscode-html-languageservice: 5.6.1
+            vscode-html-languageservice: 5.6.2
             vscode-languageserver-textdocument: 1.0.12
             vscode-uri: 3.1.0
         optionalDependencies:
             '@volar/language-service': 2.4.28
 
-    volar-service-prettier@0.0.68(@volar/language-service@2.4.28)(prettier@3.5.3):
+    volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.5.3):
         dependencies:
             vscode-uri: 3.1.0
         optionalDependencies:
             '@volar/language-service': 2.4.28
             prettier: 3.5.3
 
-    volar-service-typescript-twoslash-queries@0.0.68(@volar/language-service@2.4.28):
+    volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
         dependencies:
             vscode-uri: 3.1.0
         optionalDependencies:
             '@volar/language-service': 2.4.28
 
-    volar-service-typescript@0.0.68(@volar/language-service@2.4.28):
+    volar-service-typescript@0.0.70(@volar/language-service@2.4.28):
         dependencies:
             path-browserify: 1.0.1
             semver: 7.7.4
@@ -6687,21 +6696,21 @@ snapshots:
         optionalDependencies:
             '@volar/language-service': 2.4.28
 
-    volar-service-yaml@0.0.68(@volar/language-service@2.4.28):
+    volar-service-yaml@0.0.70(@volar/language-service@2.4.28):
         dependencies:
             vscode-uri: 3.1.0
-            yaml-language-server: 1.19.2
+            yaml-language-server: 1.20.0
         optionalDependencies:
             '@volar/language-service': 2.4.28
 
-    vscode-css-languageservice@6.3.9:
+    vscode-css-languageservice@6.3.10:
         dependencies:
             '@vscode/l10n': 0.0.18
             vscode-languageserver-textdocument: 1.0.12
             vscode-languageserver-types: 3.17.5
             vscode-uri: 3.1.0
 
-    vscode-html-languageservice@5.6.1:
+    vscode-html-languageservice@5.6.2:
         dependencies:
             '@vscode/l10n': 0.0.18
             vscode-languageserver-textdocument: 1.0.12
@@ -6753,18 +6762,17 @@ snapshots:
         dependencies:
             ansi-styles: 6.2.3
             string-width: 7.2.0
-            strip-ansi: 7.1.2
+            strip-ansi: 7.2.0
 
     xxhash-wasm@1.1.0: {}
 
     y18n@5.0.8: {}
 
-    yaml-language-server@1.19.2:
+    yaml-language-server@1.20.0:
         dependencies:
             '@vscode/l10n': 0.0.18
             ajv: 8.18.0
             ajv-draft-04: 1.0.0(ajv@8.18.0)
-            lodash: 4.17.21
             prettier: 3.5.3
             request-light: 0.5.8
             vscode-json-languageservice: 4.1.8
@@ -6808,5 +6816,7 @@ snapshots:
             zod: 3.25.76
 
     zod@3.25.76: {}
+
+    zod@4.3.6: {}
 
     zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- `astro`: 5.17.3 → 5.18.1
- `@astrojs/check`: 0.9.6 → 0.9.8
- `@astrojs/mdx`: 4.3.13 → 4.3.14
- `@astrojs/rss`: 4.0.15 → 4.0.17
- `@astrojs/sitemap`: 3.7.0 → 3.7.1
- `@tailwindcss/vite`: 4.2.0 → 4.2.2
- `tailwindcss`: 4.2.0 → 4.2.2

## Test plan

- [ ] Verify site builds without errors (`pnpm build`)
- [ ] Check for TypeScript errors (`pnpm astro check`)
- [ ] Spot-check rendered pages for visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)