### PR TITLE
Upgrade dependencies to latest including Astro 6 and TypeScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,21 +11,22 @@
     },
     "dependencies": {
         "@astrojs/check": "^0.9.8",
-        "@astrojs/mdx": "^4.3.14",
-        "@astrojs/rss": "^4.0.17",
-        "@astrojs/sitemap": "^3.7.1",
+        "@astrojs/mdx": "^5.0.3",
+        "@astrojs/rss": "^4.0.18",
+        "@astrojs/sitemap": "^3.7.2",
         "@tailwindcss/vite": "^4.2.2",
-        "astro": "^5.18.1",
+        "astro": "^6.1.5",
         "sharp": "^0.34.5",
         "tailwindcss": "^4.2.2",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.2",
+        "zod": "^4.3.6"
     },
     "devDependencies": {
-        "prettier": "3.5.3",
+        "prettier": "3.8.1",
         "prettier-plugin-astro": "0.14.1",
-        "prettier-plugin-tailwindcss": "^0.6.14",
+        "prettier-plugin-tailwindcss": "^0.7.2",
         "pretty-quick": "^4.2.2",
         "simple-git-hooks": "^2.13.1"
     },
-    "packageManager": "pnpm@10.30.0"
+    "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,22 +9,22 @@ importers:
         dependencies:
             '@astrojs/check':
                 specifier: ^0.9.8
-                version: 0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
+                version: 0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)
             '@astrojs/mdx':
-                specifier: ^4.3.14
-                version: 4.3.14(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
+                specifier: ^5.0.3
+                version: 5.0.3(astro@6.1.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(typescript@6.0.2)(yaml@2.8.3))
             '@astrojs/rss':
-                specifier: ^4.0.17
-                version: 4.0.17
+                specifier: ^4.0.18
+                version: 4.0.18
             '@astrojs/sitemap':
-                specifier: ^3.7.1
-                version: 3.7.1
+                specifier: ^3.7.2
+                version: 3.7.2
             '@tailwindcss/vite':
                 specifier: ^4.2.2
-                version: 4.2.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+                version: 4.2.2(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
             astro:
-                specifier: ^5.18.1
-                version: 5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+                specifier: ^6.1.5
+                version: 6.1.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(typescript@6.0.2)(yaml@2.8.3)
             sharp:
                 specifier: ^0.34.5
                 version: 0.34.5
@@ -32,21 +32,24 @@ importers:
                 specifier: ^4.2.2
                 version: 4.2.2
             typescript:
-                specifier: ^5.9.3
-                version: 5.9.3
+                specifier: ^6.0.2
+                version: 6.0.2
+            zod:
+                specifier: ^4.3.6
+                version: 4.3.6
         devDependencies:
             prettier:
-                specifier: 3.5.3
-                version: 3.5.3
+                specifier: 3.8.1
+                version: 3.8.1
             prettier-plugin-astro:
                 specifier: 0.14.1
                 version: 0.14.1
             prettier-plugin-tailwindcss:
-                specifier: ^0.6.14
-                version: 0.6.14(prettier-plugin-astro@0.14.1)(prettier@3.5.3)
+                specifier: ^0.7.2
+                version: 0.7.2(prettier-plugin-astro@0.14.1)(prettier@3.8.1)
             pretty-quick:
                 specifier: ^4.2.2
-                version: 4.2.2(prettier@3.5.3)
+                version: 4.2.2(prettier@3.8.1)
             simple-git-hooks:
                 specifier: ^2.13.1
                 version: 2.13.1
@@ -67,10 +70,16 @@ packages:
                 integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==,
             }
 
-    '@astrojs/internal-helpers@0.7.6':
+    '@astrojs/compiler@3.0.1':
         resolution:
             {
-                integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==,
+                integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==,
+            }
+
+    '@astrojs/internal-helpers@0.8.0':
+        resolution:
+            {
+                integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==,
             }
 
     '@astrojs/language-server@2.16.6':
@@ -88,38 +97,38 @@ packages:
             prettier-plugin-astro:
                 optional: true
 
-    '@astrojs/markdown-remark@6.3.11':
+    '@astrojs/markdown-remark@7.1.0':
         resolution:
             {
-                integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==,
+                integrity: sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==,
             }
 
-    '@astrojs/mdx@4.3.14':
+    '@astrojs/mdx@5.0.3':
         resolution:
             {
-                integrity: sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA==,
+                integrity: sha512-zv/OlM5sZZvyjHqJjR3FjJvoCgbxdqj3t4jO/gSEUNcck3BjdtMgNQw8UgPfAGe4yySdG4vjZ3OC5wUxhu7ckg==,
             }
-        engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+        engines: { node: '>=22.12.0' }
         peerDependencies:
-            astro: ^5.0.0
+            astro: ^6.0.0
 
-    '@astrojs/prism@3.3.0':
+    '@astrojs/prism@4.0.1':
         resolution:
             {
-                integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==,
+                integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==,
             }
-        engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+        engines: { node: '>=22.12.0' }
 
-    '@astrojs/rss@4.0.17':
+    '@astrojs/rss@4.0.18':
         resolution:
             {
-                integrity: sha512-eV+wdMbeVKC9+sPaV0LN8JL1LGo9YAh3GKl4Ou4nzMNLmXM/aswYpSGxVEAuHilgBZ6/++/Pv08ICmuOqX107w==,
+                integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==,
             }
 
-    '@astrojs/sitemap@3.7.1':
+    '@astrojs/sitemap@3.7.2':
         resolution:
             {
-                integrity: sha512-IzQqdTeskaMX+QDZCzMuJIp8A8C1vgzMBp/NmHNnadepHYNHcxQdGLQZYfkbd2EbRXUfOS+UDIKx8sKg0oWVdw==,
+                integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==,
             }
 
     '@astrojs/telemetry@3.3.0':
@@ -171,6 +180,18 @@ packages:
             }
         engines: { node: '>=18' }
 
+    '@clack/core@1.2.0':
+        resolution:
+            {
+                integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==,
+            }
+
+    '@clack/prompts@1.2.0':
+        resolution:
+            {
+                integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==,
+            }
+
     '@emmetio/abbreviation@2.3.3':
         resolution:
             {
@@ -213,475 +234,241 @@ packages:
                 integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==,
             }
 
-    '@emnapi/runtime@1.9.1':
+    '@emnapi/runtime@1.9.2':
         resolution:
             {
-                integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==,
+                integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==,
             }
 
-    '@esbuild/aix-ppc64@0.25.12':
+    '@esbuild/aix-ppc64@0.27.7':
         resolution:
             {
-                integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [aix]
-
-    '@esbuild/aix-ppc64@0.27.4':
-        resolution:
-            {
-                integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==,
+                integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
             }
         engines: { node: '>=18' }
         cpu: [ppc64]
         os: [aix]
 
-    '@esbuild/android-arm64@0.25.12':
+    '@esbuild/android-arm64@0.27.7':
         resolution:
             {
-                integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+                integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
         os: [android]
 
-    '@esbuild/android-arm64@0.27.4':
+    '@esbuild/android-arm@0.27.7':
         resolution:
             {
-                integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [android]
-
-    '@esbuild/android-arm@0.25.12':
-        resolution:
-            {
-                integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
+                integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
             }
         engines: { node: '>=18' }
         cpu: [arm]
         os: [android]
 
-    '@esbuild/android-arm@0.27.4':
+    '@esbuild/android-x64@0.27.7':
         resolution:
             {
-                integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [android]
-
-    '@esbuild/android-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+                integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
         os: [android]
 
-    '@esbuild/android-x64@0.27.4':
+    '@esbuild/darwin-arm64@0.27.7':
         resolution:
             {
-                integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [android]
-
-    '@esbuild/darwin-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
+                integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
         os: [darwin]
 
-    '@esbuild/darwin-arm64@0.27.4':
+    '@esbuild/darwin-x64@0.27.7':
         resolution:
             {
-                integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@esbuild/darwin-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+                integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
         os: [darwin]
 
-    '@esbuild/darwin-x64@0.27.4':
+    '@esbuild/freebsd-arm64@0.27.7':
         resolution:
             {
-                integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@esbuild/freebsd-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
+                integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
         os: [freebsd]
 
-    '@esbuild/freebsd-arm64@0.27.4':
+    '@esbuild/freebsd-x64@0.27.7':
         resolution:
             {
-                integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [freebsd]
-
-    '@esbuild/freebsd-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+                integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
         os: [freebsd]
 
-    '@esbuild/freebsd-x64@0.27.4':
+    '@esbuild/linux-arm64@0.27.7':
         resolution:
             {
-                integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@esbuild/linux-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
+                integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
         os: [linux]
 
-    '@esbuild/linux-arm64@0.27.4':
+    '@esbuild/linux-arm@0.27.7':
         resolution:
             {
-                integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [linux]
-
-    '@esbuild/linux-arm@0.25.12':
-        resolution:
-            {
-                integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+                integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
             }
         engines: { node: '>=18' }
         cpu: [arm]
         os: [linux]
 
-    '@esbuild/linux-arm@0.27.4':
+    '@esbuild/linux-ia32@0.27.7':
         resolution:
             {
-                integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [linux]
-
-    '@esbuild/linux-ia32@0.25.12':
-        resolution:
-            {
-                integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
+                integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
             }
         engines: { node: '>=18' }
         cpu: [ia32]
         os: [linux]
 
-    '@esbuild/linux-ia32@0.27.4':
+    '@esbuild/linux-loong64@0.27.7':
         resolution:
             {
-                integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [linux]
-
-    '@esbuild/linux-loong64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+                integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
             }
         engines: { node: '>=18' }
         cpu: [loong64]
         os: [linux]
 
-    '@esbuild/linux-loong64@0.27.4':
+    '@esbuild/linux-mips64el@0.27.7':
         resolution:
             {
-                integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [loong64]
-        os: [linux]
-
-    '@esbuild/linux-mips64el@0.25.12':
-        resolution:
-            {
-                integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
+                integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
             }
         engines: { node: '>=18' }
         cpu: [mips64el]
         os: [linux]
 
-    '@esbuild/linux-mips64el@0.27.4':
+    '@esbuild/linux-ppc64@0.27.7':
         resolution:
             {
-                integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [mips64el]
-        os: [linux]
-
-    '@esbuild/linux-ppc64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+                integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
             }
         engines: { node: '>=18' }
         cpu: [ppc64]
         os: [linux]
 
-    '@esbuild/linux-ppc64@0.27.4':
+    '@esbuild/linux-riscv64@0.27.7':
         resolution:
             {
-                integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [linux]
-
-    '@esbuild/linux-riscv64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
+                integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
             }
         engines: { node: '>=18' }
         cpu: [riscv64]
         os: [linux]
 
-    '@esbuild/linux-riscv64@0.27.4':
+    '@esbuild/linux-s390x@0.27.7':
         resolution:
             {
-                integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [riscv64]
-        os: [linux]
-
-    '@esbuild/linux-s390x@0.25.12':
-        resolution:
-            {
-                integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+                integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
             }
         engines: { node: '>=18' }
         cpu: [s390x]
         os: [linux]
 
-    '@esbuild/linux-s390x@0.27.4':
+    '@esbuild/linux-x64@0.27.7':
         resolution:
             {
-                integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [s390x]
-        os: [linux]
-
-    '@esbuild/linux-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
+                integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
         os: [linux]
 
-    '@esbuild/linux-x64@0.27.4':
+    '@esbuild/netbsd-arm64@0.27.7':
         resolution:
             {
-                integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [linux]
-
-    '@esbuild/netbsd-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+                integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
         os: [netbsd]
 
-    '@esbuild/netbsd-arm64@0.27.4':
+    '@esbuild/netbsd-x64@0.27.7':
         resolution:
             {
-                integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [netbsd]
-
-    '@esbuild/netbsd-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
+                integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
         os: [netbsd]
 
-    '@esbuild/netbsd-x64@0.27.4':
+    '@esbuild/openbsd-arm64@0.27.7':
         resolution:
             {
-                integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [netbsd]
-
-    '@esbuild/openbsd-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+                integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
         os: [openbsd]
 
-    '@esbuild/openbsd-arm64@0.27.4':
+    '@esbuild/openbsd-x64@0.27.7':
         resolution:
             {
-                integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openbsd]
-
-    '@esbuild/openbsd-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
+                integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
         os: [openbsd]
 
-    '@esbuild/openbsd-x64@0.27.4':
+    '@esbuild/openharmony-arm64@0.27.7':
         resolution:
             {
-                integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [openbsd]
-
-    '@esbuild/openharmony-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+                integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
         os: [openharmony]
 
-    '@esbuild/openharmony-arm64@0.27.4':
+    '@esbuild/sunos-x64@0.27.7':
         resolution:
             {
-                integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@esbuild/sunos-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
+                integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
         os: [sunos]
 
-    '@esbuild/sunos-x64@0.27.4':
+    '@esbuild/win32-arm64@0.27.7':
         resolution:
             {
-                integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [sunos]
-
-    '@esbuild/win32-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+                integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
             }
         engines: { node: '>=18' }
         cpu: [arm64]
         os: [win32]
 
-    '@esbuild/win32-arm64@0.27.4':
+    '@esbuild/win32-ia32@0.27.7':
         resolution:
             {
-                integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@esbuild/win32-ia32@0.25.12':
-        resolution:
-            {
-                integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
+                integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
             }
         engines: { node: '>=18' }
         cpu: [ia32]
         os: [win32]
 
-    '@esbuild/win32-ia32@0.27.4':
+    '@esbuild/win32-x64@0.27.7':
         resolution:
             {
-                integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [win32]
-
-    '@esbuild/win32-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [win32]
-
-    '@esbuild/win32-x64@0.27.4':
-        resolution:
-            {
-                integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==,
+                integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
             }
         engines: { node: '>=18' }
         cpu: [x64]
@@ -977,254 +764,267 @@ packages:
             rollup:
                 optional: true
 
-    '@rollup/rollup-android-arm-eabi@4.59.0':
+    '@rollup/rollup-android-arm-eabi@4.60.1':
         resolution:
             {
-                integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==,
+                integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==,
             }
         cpu: [arm]
         os: [android]
 
-    '@rollup/rollup-android-arm64@4.59.0':
+    '@rollup/rollup-android-arm64@4.60.1':
         resolution:
             {
-                integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==,
+                integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==,
             }
         cpu: [arm64]
         os: [android]
 
-    '@rollup/rollup-darwin-arm64@4.59.0':
+    '@rollup/rollup-darwin-arm64@4.60.1':
         resolution:
             {
-                integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==,
+                integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==,
             }
         cpu: [arm64]
         os: [darwin]
 
-    '@rollup/rollup-darwin-x64@4.59.0':
+    '@rollup/rollup-darwin-x64@4.60.1':
         resolution:
             {
-                integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==,
+                integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==,
             }
         cpu: [x64]
         os: [darwin]
 
-    '@rollup/rollup-freebsd-arm64@4.59.0':
+    '@rollup/rollup-freebsd-arm64@4.60.1':
         resolution:
             {
-                integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==,
+                integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==,
             }
         cpu: [arm64]
         os: [freebsd]
 
-    '@rollup/rollup-freebsd-x64@4.59.0':
+    '@rollup/rollup-freebsd-x64@4.60.1':
         resolution:
             {
-                integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==,
+                integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==,
             }
         cpu: [x64]
         os: [freebsd]
 
-    '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
         resolution:
             {
-                integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==,
+                integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==,
             }
         cpu: [arm]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    '@rollup/rollup-linux-arm-musleabihf@4.60.1':
         resolution:
             {
-                integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==,
+                integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==,
             }
         cpu: [arm]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    '@rollup/rollup-linux-arm64-gnu@4.60.1':
         resolution:
             {
-                integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==,
+                integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==,
             }
         cpu: [arm64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-arm64-musl@4.59.0':
+    '@rollup/rollup-linux-arm64-musl@4.60.1':
         resolution:
             {
-                integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==,
+                integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==,
             }
         cpu: [arm64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    '@rollup/rollup-linux-loong64-gnu@4.60.1':
         resolution:
             {
-                integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==,
+                integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==,
             }
         cpu: [loong64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-loong64-musl@4.59.0':
+    '@rollup/rollup-linux-loong64-musl@4.60.1':
         resolution:
             {
-                integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==,
+                integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==,
             }
         cpu: [loong64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    '@rollup/rollup-linux-ppc64-gnu@4.60.1':
         resolution:
             {
-                integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==,
+                integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==,
             }
         cpu: [ppc64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    '@rollup/rollup-linux-ppc64-musl@4.60.1':
         resolution:
             {
-                integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==,
+                integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==,
             }
         cpu: [ppc64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    '@rollup/rollup-linux-riscv64-gnu@4.60.1':
         resolution:
             {
-                integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==,
+                integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==,
             }
         cpu: [riscv64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    '@rollup/rollup-linux-riscv64-musl@4.60.1':
         resolution:
             {
-                integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==,
+                integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==,
             }
         cpu: [riscv64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    '@rollup/rollup-linux-s390x-gnu@4.60.1':
         resolution:
             {
-                integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==,
+                integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==,
             }
         cpu: [s390x]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-x64-gnu@4.59.0':
+    '@rollup/rollup-linux-x64-gnu@4.60.1':
         resolution:
             {
-                integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==,
+                integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==,
             }
         cpu: [x64]
         os: [linux]
         libc: [glibc]
 
-    '@rollup/rollup-linux-x64-musl@4.59.0':
+    '@rollup/rollup-linux-x64-musl@4.60.1':
         resolution:
             {
-                integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==,
+                integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==,
             }
         cpu: [x64]
         os: [linux]
         libc: [musl]
 
-    '@rollup/rollup-openbsd-x64@4.59.0':
+    '@rollup/rollup-openbsd-x64@4.60.1':
         resolution:
             {
-                integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==,
+                integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==,
             }
         cpu: [x64]
         os: [openbsd]
 
-    '@rollup/rollup-openharmony-arm64@4.59.0':
+    '@rollup/rollup-openharmony-arm64@4.60.1':
         resolution:
             {
-                integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==,
+                integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==,
             }
         cpu: [arm64]
         os: [openharmony]
 
-    '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    '@rollup/rollup-win32-arm64-msvc@4.60.1':
         resolution:
             {
-                integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==,
+                integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==,
             }
         cpu: [arm64]
         os: [win32]
 
-    '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    '@rollup/rollup-win32-ia32-msvc@4.60.1':
         resolution:
             {
-                integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==,
+                integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==,
             }
         cpu: [ia32]
         os: [win32]
 
-    '@rollup/rollup-win32-x64-gnu@4.59.0':
+    '@rollup/rollup-win32-x64-gnu@4.60.1':
         resolution:
             {
-                integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==,
+                integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==,
             }
         cpu: [x64]
         os: [win32]
 
-    '@rollup/rollup-win32-x64-msvc@4.59.0':
+    '@rollup/rollup-win32-x64-msvc@4.60.1':
         resolution:
             {
-                integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==,
+                integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==,
             }
         cpu: [x64]
         os: [win32]
 
-    '@shikijs/core@3.23.0':
+    '@shikijs/core@4.0.2':
         resolution:
             {
-                integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
+                integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==,
             }
+        engines: { node: '>=20' }
 
-    '@shikijs/engine-javascript@3.23.0':
+    '@shikijs/engine-javascript@4.0.2':
         resolution:
             {
-                integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
+                integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==,
             }
+        engines: { node: '>=20' }
 
-    '@shikijs/engine-oniguruma@3.23.0':
+    '@shikijs/engine-oniguruma@4.0.2':
         resolution:
             {
-                integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
+                integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==,
             }
+        engines: { node: '>=20' }
 
-    '@shikijs/langs@3.23.0':
+    '@shikijs/langs@4.0.2':
         resolution:
             {
-                integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
+                integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==,
             }
+        engines: { node: '>=20' }
 
-    '@shikijs/themes@3.23.0':
+    '@shikijs/primitive@4.0.2':
         resolution:
             {
-                integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
+                integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==,
             }
+        engines: { node: '>=20' }
 
-    '@shikijs/types@3.23.0':
+    '@shikijs/themes@4.0.2':
         resolution:
             {
-                integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
+                integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==,
             }
+        engines: { node: '>=20' }
+
+    '@shikijs/types@4.0.2':
+        resolution:
+            {
+                integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==,
+            }
+        engines: { node: '>=20' }
 
     '@shikijs/vscode-textmate@10.0.2':
         resolution:
@@ -1419,10 +1219,10 @@ packages:
                 integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==,
             }
 
-    '@types/node@24.12.0':
+    '@types/node@24.12.2':
         resolution:
             {
-                integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==,
+                integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==,
             }
 
     '@types/sax@1.2.7':
@@ -1532,12 +1332,6 @@ packages:
                 integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
             }
 
-    ansi-align@3.0.1:
-        resolution:
-            {
-                integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
-            }
-
     ansi-regex@5.0.1:
         resolution:
             {
@@ -1545,26 +1339,12 @@ packages:
             }
         engines: { node: '>=8' }
 
-    ansi-regex@6.2.2:
-        resolution:
-            {
-                integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
-            }
-        engines: { node: '>=12' }
-
     ansi-styles@4.3.0:
         resolution:
             {
                 integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
             }
         engines: { node: '>=8' }
-
-    ansi-styles@6.2.3:
-        resolution:
-            {
-                integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
-            }
-        engines: { node: '>=12' }
 
     anymatch@3.1.3:
         resolution:
@@ -1605,17 +1385,12 @@ packages:
             }
         hasBin: true
 
-    astro@5.18.1:
+    astro@6.1.5:
         resolution:
             {
-                integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==,
+                integrity: sha512-AJVw/JlssxUCBFi3Hp4djL8Pt7wUQqStBBawCd8cNGBBM2lBzp/rXGguzt4OcMfW+86fs0hpFwMyopHM2r6d3g==,
             }
-        engines:
-            {
-                node: 18.20.8 || ^20.3.0 || >=22.0.0,
-                npm: '>=9.6.5',
-                pnpm: '>=7.1.0',
-            }
+        engines: { node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0' }
         hasBin: true
 
     axobject-query@4.1.0:
@@ -1631,44 +1406,17 @@ packages:
                 integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
             }
 
-    base-64@1.0.0:
-        resolution:
-            {
-                integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==,
-            }
-
     boolbase@1.0.0:
         resolution:
             {
                 integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
             }
 
-    boxen@8.0.1:
-        resolution:
-            {
-                integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==,
-            }
-        engines: { node: '>=18' }
-
-    camelcase@8.0.0:
-        resolution:
-            {
-                integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==,
-            }
-        engines: { node: '>=16' }
-
     ccount@2.0.1:
         resolution:
             {
                 integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
             }
-
-    chalk@5.6.2:
-        resolution:
-            {
-                integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
-            }
-        engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
 
     character-entities-html4@2.1.0:
         resolution:
@@ -1714,13 +1462,6 @@ packages:
                 integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==,
             }
         engines: { node: '>=8' }
-
-    cli-boxes@3.0.0:
-        resolution:
-            {
-                integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
-            }
-        engines: { node: '>=10' }
 
     cliui@8.0.1:
         resolution:
@@ -1768,16 +1509,17 @@ packages:
             }
         engines: { node: '>=16' }
 
-    common-ancestor-path@1.0.1:
+    common-ancestor-path@2.0.0:
         resolution:
             {
-                integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
+                integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==,
             }
+        engines: { node: '>= 18' }
 
-    cookie-es@1.2.2:
+    cookie-es@1.2.3:
         resolution:
             {
-                integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==,
+                integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==,
             }
 
     cookie@1.1.1:
@@ -1821,14 +1563,6 @@ packages:
             }
         engines: { node: '>= 6' }
 
-    cssesc@3.0.0:
-        resolution:
-            {
-                integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
-            }
-        engines: { node: '>=4' }
-        hasBin: true
-
     csso@5.0.5:
         resolution:
             {
@@ -1855,10 +1589,10 @@ packages:
                 integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
             }
 
-    defu@6.1.4:
+    defu@6.1.7:
         resolution:
             {
-                integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==,
+                integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==,
             }
 
     dequal@2.0.3:
@@ -1881,17 +1615,10 @@ packages:
             }
         engines: { node: '>=8' }
 
-    deterministic-object-hash@2.0.2:
+    devalue@5.7.1:
         resolution:
             {
-                integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==,
-            }
-        engines: { node: '>=18' }
-
-    devalue@5.6.4:
-        resolution:
-            {
-                integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==,
+                integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==,
             }
 
     devlop@1.1.0:
@@ -1900,10 +1627,10 @@ packages:
                 integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
             }
 
-    diff@8.0.3:
+    diff@8.0.4:
         resolution:
             {
-                integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==,
+                integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==,
             }
         engines: { node: '>=0.3.1' }
 
@@ -1951,12 +1678,6 @@ packages:
                 integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==,
             }
 
-    emoji-regex@10.6.0:
-        resolution:
-            {
-                integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
-            }
-
     emoji-regex@8.0.0:
         resolution:
             {
@@ -1984,10 +1705,10 @@ packages:
             }
         engines: { node: '>=0.12' }
 
-    es-module-lexer@1.7.0:
+    es-module-lexer@2.0.0:
         resolution:
             {
-                integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+                integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
             }
 
     esast-util-from-estree@2.0.0:
@@ -2002,18 +1723,10 @@ packages:
                 integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
             }
 
-    esbuild@0.25.12:
+    esbuild@0.27.7:
         resolution:
             {
-                integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    esbuild@0.27.4:
-        resolution:
-            {
-                integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==,
+                integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
             }
         engines: { node: '>=18' }
         hasBin: true
@@ -2098,10 +1811,28 @@ packages:
                 integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
             }
 
+    fast-string-truncated-width@1.2.1:
+        resolution:
+            {
+                integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==,
+            }
+
+    fast-string-width@1.1.0:
+        resolution:
+            {
+                integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==,
+            }
+
     fast-uri@3.1.0:
         resolution:
             {
                 integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+            }
+
+    fast-wrap-ansi@0.1.6:
+        resolution:
+            {
+                integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==,
             }
 
     fast-xml-builder@1.1.4:
@@ -2110,10 +1841,10 @@ packages:
                 integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==,
             }
 
-    fast-xml-parser@5.4.1:
+    fast-xml-parser@5.5.11:
         resolution:
             {
-                integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==,
+                integrity: sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==,
             }
         hasBin: true
 
@@ -2164,13 +1895,6 @@ packages:
             }
         engines: { node: 6.* || 8.* || >= 10.* }
 
-    get-east-asian-width@1.5.0:
-        resolution:
-            {
-                integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==,
-            }
-        engines: { node: '>=18' }
-
     github-slugger@2.0.0:
         resolution:
             {
@@ -2183,10 +1907,10 @@ packages:
                 integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
             }
 
-    h3@1.15.9:
+    h3@1.15.11:
         resolution:
             {
-                integrity: sha512-H7UPnyIupUOYUQu7f2x7ABVeMyF/IbJjqn20WSXpMdnQB260luADUkSgJU7QTWLutq8h3tUayMQ1DdbSYX5LkA==,
+                integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==,
             }
 
     hast-util-from-html@2.0.3:
@@ -2285,12 +2009,6 @@ packages:
                 integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
             }
         engines: { node: '>= 4' }
-
-    import-meta-resolve@4.2.0:
-        resolution:
-            {
-                integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
-            }
 
     inline-style-parser@0.2.7:
         resolution:
@@ -2396,13 +2114,6 @@ packages:
             {
                 integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==,
             }
-
-    kleur@3.0.3:
-        resolution:
-            {
-                integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
-            }
-        engines: { node: '>=6' }
 
     kleur@4.1.5:
         resolution:
@@ -2527,10 +2238,10 @@ packages:
                 integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
             }
 
-    lru-cache@11.2.7:
+    lru-cache@11.3.3:
         resolution:
             {
-                integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==,
+                integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==,
             }
         engines: { node: 20 || >=22 }
 
@@ -2955,6 +2666,12 @@ packages:
                 integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
             }
 
+    obug@2.1.1:
+        resolution:
+            {
+                integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+            }
+
     ofetch@1.5.1:
         resolution:
             {
@@ -2979,26 +2696,26 @@ packages:
                 integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==,
             }
 
-    p-limit@6.2.0:
+    p-limit@7.3.0:
         resolution:
             {
-                integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==,
+                integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==,
             }
-        engines: { node: '>=18' }
+        engines: { node: '>=20' }
 
-    p-queue@8.1.1:
+    p-queue@9.1.2:
         resolution:
             {
-                integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==,
+                integrity: sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==,
             }
-        engines: { node: '>=18' }
+        engines: { node: '>=20' }
 
-    p-timeout@6.1.4:
+    p-timeout@7.0.1:
         resolution:
             {
-                integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==,
+                integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==,
             }
-        engines: { node: '>=14.16' }
+        engines: { node: '>=20' }
 
     package-manager-detector@1.6.0:
         resolution:
@@ -3030,10 +2747,10 @@ packages:
                 integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==,
             }
 
-    path-expression-matcher@1.2.0:
+    path-expression-matcher@1.4.0:
         resolution:
             {
-                integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==,
+                integrity: sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==,
             }
         engines: { node: '>=14.0.0' }
 
@@ -3049,24 +2766,24 @@ packages:
                 integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
             }
 
-    picomatch@2.3.1:
+    picomatch@2.3.2:
         resolution:
             {
-                integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+                integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
             }
         engines: { node: '>=8.6' }
 
-    picomatch@4.0.3:
+    picomatch@4.0.4:
         resolution:
             {
-                integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+                integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
             }
         engines: { node: '>=12' }
 
-    postcss@8.5.8:
+    postcss@8.5.9:
         resolution:
             {
-                integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
+                integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==,
             }
         engines: { node: ^10 || ^12 || >=14 }
 
@@ -3077,12 +2794,12 @@ packages:
             }
         engines: { node: ^14.15.0 || >=16.0.0 }
 
-    prettier-plugin-tailwindcss@0.6.14:
+    prettier-plugin-tailwindcss@0.7.2:
         resolution:
             {
-                integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==,
+                integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==,
             }
-        engines: { node: '>=14.21.3' }
+        engines: { node: '>=20.19' }
         peerDependencies:
             '@ianvs/prettier-plugin-sort-imports': '*'
             '@prettier/plugin-hermes': '*'
@@ -3094,14 +2811,12 @@ packages:
             prettier: ^3.0
             prettier-plugin-astro: '*'
             prettier-plugin-css-order: '*'
-            prettier-plugin-import-sort: '*'
             prettier-plugin-jsdoc: '*'
             prettier-plugin-marko: '*'
             prettier-plugin-multiline-arrays: '*'
             prettier-plugin-organize-attributes: '*'
             prettier-plugin-organize-imports: '*'
             prettier-plugin-sort-imports: '*'
-            prettier-plugin-style-order: '*'
             prettier-plugin-svelte: '*'
         peerDependenciesMeta:
             '@ianvs/prettier-plugin-sort-imports':
@@ -3122,8 +2837,6 @@ packages:
                 optional: true
             prettier-plugin-css-order:
                 optional: true
-            prettier-plugin-import-sort:
-                optional: true
             prettier-plugin-jsdoc:
                 optional: true
             prettier-plugin-marko:
@@ -3136,15 +2849,13 @@ packages:
                 optional: true
             prettier-plugin-sort-imports:
                 optional: true
-            prettier-plugin-style-order:
-                optional: true
             prettier-plugin-svelte:
                 optional: true
 
-    prettier@3.5.3:
+    prettier@3.8.1:
         resolution:
             {
-                integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==,
+                integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
             }
         engines: { node: '>=14' }
         hasBin: true
@@ -3165,13 +2876,6 @@ packages:
                 integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==,
             }
         engines: { node: '>=6' }
-
-    prompts@2.4.2:
-        resolution:
-            {
-                integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
-            }
-        engines: { node: '>= 6' }
 
     property-information@7.1.0:
         resolution:
@@ -3360,10 +3064,10 @@ packages:
                 integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==,
             }
 
-    rollup@4.59.0:
+    rollup@4.60.1:
         resolution:
             {
-                integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==,
+                integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==,
             }
         engines: { node: '>=18.0.0', npm: '>=8.0.0' }
         hasBin: true
@@ -3402,11 +3106,12 @@ packages:
             }
         engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
 
-    shiki@3.23.0:
+    shiki@4.0.2:
         resolution:
             {
-                integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
+                integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==,
             }
+        engines: { node: '>=20' }
 
     simple-git-hooks@2.13.1:
         resolution:
@@ -3429,10 +3134,10 @@ packages:
         engines: { node: '>=20.19.5', npm: '>=10.8.2' }
         hasBin: true
 
-    smol-toml@1.6.0:
+    smol-toml@1.6.1:
         resolution:
             {
-                integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==,
+                integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==,
             }
         engines: { node: '>= 18' }
 
@@ -3469,13 +3174,6 @@ packages:
             }
         engines: { node: '>=8' }
 
-    string-width@7.2.0:
-        resolution:
-            {
-                integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
-            }
-        engines: { node: '>=18' }
-
     stringify-entities@4.0.4:
         resolution:
             {
@@ -3489,17 +3187,10 @@ packages:
             }
         engines: { node: '>=8' }
 
-    strip-ansi@7.2.0:
+    strnum@2.2.3:
         resolution:
             {
-                integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
-            }
-        engines: { node: '>=12' }
-
-    strnum@2.2.1:
-        resolution:
-            {
-                integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==,
+                integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==,
             }
 
     style-to-js@1.1.21:
@@ -3534,10 +3225,10 @@ packages:
                 integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==,
             }
 
-    tapable@2.3.0:
+    tapable@2.3.2:
         resolution:
             {
-                integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==,
+                integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==,
             }
         engines: { node: '>=6' }
 
@@ -3547,23 +3238,30 @@ packages:
                 integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==,
             }
 
+    tinyclip@0.1.12:
+        resolution:
+            {
+                integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==,
+            }
+        engines: { node: ^16.14.0 || >= 17.3.0 }
+
     tinyexec@0.3.2:
         resolution:
             {
                 integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
             }
 
-    tinyexec@1.0.4:
+    tinyexec@1.1.1:
         resolution:
             {
-                integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==,
+                integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==,
             }
         engines: { node: '>=18' }
 
-    tinyglobby@0.2.15:
+    tinyglobby@0.2.16:
         resolution:
             {
-                integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+                integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
             }
         engines: { node: '>=12.0.0' }
 
@@ -3598,13 +3296,6 @@ packages:
                 integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
             }
 
-    type-fest@4.41.0:
-        resolution:
-            {
-                integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
-            }
-        engines: { node: '>=16' }
-
     typesafe-path@0.2.2:
         resolution:
             {
@@ -3617,10 +3308,10 @@ packages:
                 integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==,
             }
 
-    typescript@5.9.3:
+    typescript@6.0.2:
         resolution:
             {
-                integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+                integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==,
             }
         engines: { node: '>=14.17' }
         hasBin: true
@@ -3721,10 +3412,10 @@ packages:
                 integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
             }
 
-    unstorage@1.17.4:
+    unstorage@1.17.5:
         resolution:
             {
-                integrity: sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==,
+                integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==,
             }
         peerDependencies:
             '@azure/app-configuration': ^1.8.0
@@ -3804,22 +3495,22 @@ packages:
                 integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
             }
 
-    vite@6.4.1:
+    vite@7.3.2:
         resolution:
             {
-                integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==,
+                integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==,
             }
-        engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+        engines: { node: ^20.19.0 || >=22.12.0 }
         hasBin: true
         peerDependencies:
-            '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+            '@types/node': ^20.19.0 || >=22.12.0
             jiti: '>=1.21.0'
-            less: '*'
+            less: ^4.0.0
             lightningcss: ^1.21.0
-            sass: '*'
-            sass-embedded: '*'
-            stylus: '*'
-            sugarss: '*'
+            sass: ^1.70.0
+            sass-embedded: ^1.70.0
+            stylus: '>=0.54.8'
+            sugarss: ^5.0.0
             terser: ^5.16.0
             tsx: ^4.8.1
             yaml: ^2.4.2
@@ -3847,13 +3538,13 @@ packages:
             yaml:
                 optional: true
 
-    vitefu@1.1.2:
+    vitefu@1.1.3:
         resolution:
             {
-                integrity: sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==,
+                integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==,
             }
         peerDependencies:
-            vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
+            vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
         peerDependenciesMeta:
             vite:
                 optional: true
@@ -4014,26 +3705,12 @@ packages:
             }
         engines: { node: '>=4' }
 
-    widest-line@5.0.0:
-        resolution:
-            {
-                integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==,
-            }
-        engines: { node: '>=18' }
-
     wrap-ansi@7.0.0:
         resolution:
             {
                 integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
             }
         engines: { node: '>=10' }
-
-    wrap-ansi@9.0.2:
-        resolution:
-            {
-                integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
-            }
-        engines: { node: '>=18' }
 
     xxhash-wasm@1.1.0:
         resolution:
@@ -4063,10 +3740,10 @@ packages:
         engines: { node: '>= 14' }
         hasBin: true
 
-    yaml@2.8.2:
+    yaml@2.8.3:
         resolution:
             {
-                integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==,
+                integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
             }
         engines: { node: '>= 14.6' }
         hasBin: true
@@ -4077,6 +3754,13 @@ packages:
                 integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
             }
         engines: { node: '>=12' }
+
+    yargs-parser@22.0.0:
+        resolution:
+            {
+                integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
+            }
+        engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
 
     yargs@17.7.2:
         resolution:
@@ -4092,43 +3776,6 @@ packages:
             }
         engines: { node: '>=12.20' }
 
-    yocto-spinner@0.2.3:
-        resolution:
-            {
-                integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==,
-            }
-        engines: { node: '>=18.19' }
-
-    yoctocolors@2.1.2:
-        resolution:
-            {
-                integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==,
-            }
-        engines: { node: '>=18' }
-
-    zod-to-json-schema@3.25.1:
-        resolution:
-            {
-                integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==,
-            }
-        peerDependencies:
-            zod: ^3.25 || ^4
-
-    zod-to-ts@1.2.0:
-        resolution:
-            {
-                integrity: sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==,
-            }
-        peerDependencies:
-            typescript: ^4.9.4 || ^5.0.2
-            zod: ^3
-
-    zod@3.25.76:
-        resolution:
-            {
-                integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
-            }
-
     zod@4.3.6:
         resolution:
             {
@@ -4142,12 +3789,12 @@ packages:
             }
 
 snapshots:
-    '@astrojs/check@0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
+    '@astrojs/check@0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)':
         dependencies:
-            '@astrojs/language-server': 2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)
+            '@astrojs/language-server': 2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)
             chokidar: 4.0.3
             kleur: 4.1.5
-            typescript: 5.9.3
+            typescript: 6.0.2
             yargs: 17.7.2
         transitivePeerDependencies:
             - prettier
@@ -4155,42 +3802,45 @@ snapshots:
 
     '@astrojs/compiler@2.13.1': {}
 
-    '@astrojs/internal-helpers@0.7.6': {}
+    '@astrojs/compiler@3.0.1': {}
 
-    '@astrojs/language-server@2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.9.3)':
+    '@astrojs/internal-helpers@0.8.0':
+        dependencies:
+            picomatch: 4.0.4
+
+    '@astrojs/language-server@2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)':
         dependencies:
             '@astrojs/compiler': 2.13.1
             '@astrojs/yaml2ts': 0.2.3
             '@jridgewell/sourcemap-codec': 1.5.5
-            '@volar/kit': 2.4.28(typescript@5.9.3)
+            '@volar/kit': 2.4.28(typescript@6.0.2)
             '@volar/language-core': 2.4.28
             '@volar/language-server': 2.4.28
             '@volar/language-service': 2.4.28
             muggle-string: 0.4.1
-            tinyglobby: 0.2.15
+            tinyglobby: 0.2.16
             volar-service-css: 0.0.70(@volar/language-service@2.4.28)
             volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
             volar-service-html: 0.0.70(@volar/language-service@2.4.28)
-            volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.5.3)
+            volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.8.1)
             volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
             volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
             volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
             vscode-html-languageservice: 5.6.2
             vscode-uri: 3.1.0
         optionalDependencies:
-            prettier: 3.5.3
+            prettier: 3.8.1
             prettier-plugin-astro: 0.14.1
         transitivePeerDependencies:
             - typescript
 
-    '@astrojs/markdown-remark@6.3.11':
+    '@astrojs/markdown-remark@7.1.0':
         dependencies:
-            '@astrojs/internal-helpers': 0.7.6
-            '@astrojs/prism': 3.3.0
+            '@astrojs/internal-helpers': 0.8.0
+            '@astrojs/prism': 4.0.1
             github-slugger: 2.0.0
             hast-util-from-html: 2.0.3
             hast-util-to-text: 4.0.2
-            import-meta-resolve: 4.2.0
             js-yaml: 4.1.1
             mdast-util-definitions: 6.0.0
             rehype-raw: 7.0.0
@@ -4199,8 +3849,9 @@ snapshots:
             remark-parse: 11.0.0
             remark-rehype: 11.1.2
             remark-smartypants: 3.0.2
-            shiki: 3.23.0
-            smol-toml: 1.6.0
+            retext-smartypants: 6.2.0
+            shiki: 4.0.2
+            smol-toml: 1.6.1
             unified: 11.0.5
             unist-util-remove-position: 5.0.0
             unist-util-visit: 5.1.0
@@ -4209,13 +3860,13 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))':
+    '@astrojs/mdx@5.0.3(astro@6.1.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(typescript@6.0.2)(yaml@2.8.3))':
         dependencies:
-            '@astrojs/markdown-remark': 6.3.11
+            '@astrojs/markdown-remark': 7.1.0
             '@mdx-js/mdx': 3.1.1
             acorn: 8.16.0
-            astro: 5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
-            es-module-lexer: 1.7.0
+            astro: 6.1.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(typescript@6.0.2)(yaml@2.8.3)
+            es-module-lexer: 2.0.0
             estree-util-visit: 2.0.0
             hast-util-to-html: 9.0.5
             piccolore: 0.1.3
@@ -4228,17 +3879,17 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@astrojs/prism@3.3.0':
+    '@astrojs/prism@4.0.1':
         dependencies:
             prismjs: 1.30.0
 
-    '@astrojs/rss@4.0.17':
+    '@astrojs/rss@4.0.18':
         dependencies:
-            fast-xml-parser: 5.4.1
+            fast-xml-parser: 5.5.11
             piccolore: 0.1.3
             zod: 4.3.6
 
-    '@astrojs/sitemap@3.7.1':
+    '@astrojs/sitemap@3.7.2':
         dependencies:
             sitemap: 9.0.1
             stream-replace-string: 2.0.0
@@ -4258,7 +3909,7 @@ snapshots:
 
     '@astrojs/yaml2ts@0.2.3':
         dependencies:
-            yaml: 2.8.2
+            yaml: 2.8.3
 
     '@babel/helper-string-parser@7.27.1': {}
 
@@ -4276,6 +3927,18 @@ snapshots:
     '@capsizecss/unpack@4.0.0':
         dependencies:
             fontkitten: 1.0.3
+
+    '@clack/core@1.2.0':
+        dependencies:
+            fast-wrap-ansi: 0.1.6
+            sisteransi: 1.0.5
+
+    '@clack/prompts@1.2.0':
+        dependencies:
+            '@clack/core': 1.2.0
+            fast-string-width: 1.1.0
+            fast-wrap-ansi: 0.1.6
+            sisteransi: 1.0.5
 
     '@emmetio/abbreviation@2.3.3':
         dependencies:
@@ -4300,165 +3963,87 @@ snapshots:
 
     '@emmetio/stream-reader@2.2.0': {}
 
-    '@emnapi/runtime@1.9.1':
+    '@emnapi/runtime@1.9.2':
         dependencies:
             tslib: 2.8.1
         optional: true
 
-    '@esbuild/aix-ppc64@0.25.12':
+    '@esbuild/aix-ppc64@0.27.7':
         optional: true
 
-    '@esbuild/aix-ppc64@0.27.4':
+    '@esbuild/android-arm64@0.27.7':
         optional: true
 
-    '@esbuild/android-arm64@0.25.12':
+    '@esbuild/android-arm@0.27.7':
         optional: true
 
-    '@esbuild/android-arm64@0.27.4':
+    '@esbuild/android-x64@0.27.7':
         optional: true
 
-    '@esbuild/android-arm@0.25.12':
+    '@esbuild/darwin-arm64@0.27.7':
         optional: true
 
-    '@esbuild/android-arm@0.27.4':
+    '@esbuild/darwin-x64@0.27.7':
         optional: true
 
-    '@esbuild/android-x64@0.25.12':
+    '@esbuild/freebsd-arm64@0.27.7':
         optional: true
 
-    '@esbuild/android-x64@0.27.4':
+    '@esbuild/freebsd-x64@0.27.7':
         optional: true
 
-    '@esbuild/darwin-arm64@0.25.12':
+    '@esbuild/linux-arm64@0.27.7':
         optional: true
 
-    '@esbuild/darwin-arm64@0.27.4':
+    '@esbuild/linux-arm@0.27.7':
         optional: true
 
-    '@esbuild/darwin-x64@0.25.12':
+    '@esbuild/linux-ia32@0.27.7':
         optional: true
 
-    '@esbuild/darwin-x64@0.27.4':
+    '@esbuild/linux-loong64@0.27.7':
         optional: true
 
-    '@esbuild/freebsd-arm64@0.25.12':
+    '@esbuild/linux-mips64el@0.27.7':
         optional: true
 
-    '@esbuild/freebsd-arm64@0.27.4':
+    '@esbuild/linux-ppc64@0.27.7':
         optional: true
 
-    '@esbuild/freebsd-x64@0.25.12':
+    '@esbuild/linux-riscv64@0.27.7':
         optional: true
 
-    '@esbuild/freebsd-x64@0.27.4':
+    '@esbuild/linux-s390x@0.27.7':
         optional: true
 
-    '@esbuild/linux-arm64@0.25.12':
+    '@esbuild/linux-x64@0.27.7':
         optional: true
 
-    '@esbuild/linux-arm64@0.27.4':
+    '@esbuild/netbsd-arm64@0.27.7':
         optional: true
 
-    '@esbuild/linux-arm@0.25.12':
+    '@esbuild/netbsd-x64@0.27.7':
         optional: true
 
-    '@esbuild/linux-arm@0.27.4':
+    '@esbuild/openbsd-arm64@0.27.7':
         optional: true
 
-    '@esbuild/linux-ia32@0.25.12':
+    '@esbuild/openbsd-x64@0.27.7':
         optional: true
 
-    '@esbuild/linux-ia32@0.27.4':
+    '@esbuild/openharmony-arm64@0.27.7':
         optional: true
 
-    '@esbuild/linux-loong64@0.25.12':
+    '@esbuild/sunos-x64@0.27.7':
         optional: true
 
-    '@esbuild/linux-loong64@0.27.4':
+    '@esbuild/win32-arm64@0.27.7':
         optional: true
 
-    '@esbuild/linux-mips64el@0.25.12':
+    '@esbuild/win32-ia32@0.27.7':
         optional: true
 
-    '@esbuild/linux-mips64el@0.27.4':
-        optional: true
-
-    '@esbuild/linux-ppc64@0.25.12':
-        optional: true
-
-    '@esbuild/linux-ppc64@0.27.4':
-        optional: true
-
-    '@esbuild/linux-riscv64@0.25.12':
-        optional: true
-
-    '@esbuild/linux-riscv64@0.27.4':
-        optional: true
-
-    '@esbuild/linux-s390x@0.25.12':
-        optional: true
-
-    '@esbuild/linux-s390x@0.27.4':
-        optional: true
-
-    '@esbuild/linux-x64@0.25.12':
-        optional: true
-
-    '@esbuild/linux-x64@0.27.4':
-        optional: true
-
-    '@esbuild/netbsd-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/netbsd-arm64@0.27.4':
-        optional: true
-
-    '@esbuild/netbsd-x64@0.25.12':
-        optional: true
-
-    '@esbuild/netbsd-x64@0.27.4':
-        optional: true
-
-    '@esbuild/openbsd-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/openbsd-arm64@0.27.4':
-        optional: true
-
-    '@esbuild/openbsd-x64@0.25.12':
-        optional: true
-
-    '@esbuild/openbsd-x64@0.27.4':
-        optional: true
-
-    '@esbuild/openharmony-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/openharmony-arm64@0.27.4':
-        optional: true
-
-    '@esbuild/sunos-x64@0.25.12':
-        optional: true
-
-    '@esbuild/sunos-x64@0.27.4':
-        optional: true
-
-    '@esbuild/win32-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/win32-arm64@0.27.4':
-        optional: true
-
-    '@esbuild/win32-ia32@0.25.12':
-        optional: true
-
-    '@esbuild/win32-ia32@0.27.4':
-        optional: true
-
-    '@esbuild/win32-x64@0.25.12':
-        optional: true
-
-    '@esbuild/win32-x64@0.27.4':
+    '@esbuild/win32-x64@0.27.7':
         optional: true
 
     '@img/colour@1.1.0': {}
@@ -4545,7 +4130,7 @@ snapshots:
 
     '@img/sharp-wasm32@0.34.5':
         dependencies:
-            '@emnapi/runtime': 1.9.1
+            '@emnapi/runtime': 1.9.2
         optional: true
 
     '@img/sharp-win32-arm64@0.34.5':
@@ -4610,116 +4195,123 @@ snapshots:
 
     '@pkgr/core@0.2.9': {}
 
-    '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
+    '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
         dependencies:
             '@types/estree': 1.0.8
             estree-walker: 2.0.2
-            picomatch: 4.0.3
+            picomatch: 4.0.4
         optionalDependencies:
-            rollup: 4.59.0
+            rollup: 4.60.1
 
-    '@rollup/rollup-android-arm-eabi@4.59.0':
+    '@rollup/rollup-android-arm-eabi@4.60.1':
         optional: true
 
-    '@rollup/rollup-android-arm64@4.59.0':
+    '@rollup/rollup-android-arm64@4.60.1':
         optional: true
 
-    '@rollup/rollup-darwin-arm64@4.59.0':
+    '@rollup/rollup-darwin-arm64@4.60.1':
         optional: true
 
-    '@rollup/rollup-darwin-x64@4.59.0':
+    '@rollup/rollup-darwin-x64@4.60.1':
         optional: true
 
-    '@rollup/rollup-freebsd-arm64@4.59.0':
+    '@rollup/rollup-freebsd-arm64@4.60.1':
         optional: true
 
-    '@rollup/rollup-freebsd-x64@4.59.0':
+    '@rollup/rollup-freebsd-x64@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    '@rollup/rollup-linux-arm-musleabihf@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    '@rollup/rollup-linux-arm64-gnu@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-arm64-musl@4.59.0':
+    '@rollup/rollup-linux-arm64-musl@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    '@rollup/rollup-linux-loong64-gnu@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-loong64-musl@4.59.0':
+    '@rollup/rollup-linux-loong64-musl@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    '@rollup/rollup-linux-ppc64-gnu@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    '@rollup/rollup-linux-ppc64-musl@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    '@rollup/rollup-linux-riscv64-gnu@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    '@rollup/rollup-linux-riscv64-musl@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    '@rollup/rollup-linux-s390x-gnu@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-x64-gnu@4.59.0':
+    '@rollup/rollup-linux-x64-gnu@4.60.1':
         optional: true
 
-    '@rollup/rollup-linux-x64-musl@4.59.0':
+    '@rollup/rollup-linux-x64-musl@4.60.1':
         optional: true
 
-    '@rollup/rollup-openbsd-x64@4.59.0':
+    '@rollup/rollup-openbsd-x64@4.60.1':
         optional: true
 
-    '@rollup/rollup-openharmony-arm64@4.59.0':
+    '@rollup/rollup-openharmony-arm64@4.60.1':
         optional: true
 
-    '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    '@rollup/rollup-win32-arm64-msvc@4.60.1':
         optional: true
 
-    '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    '@rollup/rollup-win32-ia32-msvc@4.60.1':
         optional: true
 
-    '@rollup/rollup-win32-x64-gnu@4.59.0':
+    '@rollup/rollup-win32-x64-gnu@4.60.1':
         optional: true
 
-    '@rollup/rollup-win32-x64-msvc@4.59.0':
+    '@rollup/rollup-win32-x64-msvc@4.60.1':
         optional: true
 
-    '@shikijs/core@3.23.0':
+    '@shikijs/core@4.0.2':
         dependencies:
-            '@shikijs/types': 3.23.0
+            '@shikijs/primitive': 4.0.2
+            '@shikijs/types': 4.0.2
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
             hast-util-to-html: 9.0.5
 
-    '@shikijs/engine-javascript@3.23.0':
+    '@shikijs/engine-javascript@4.0.2':
         dependencies:
-            '@shikijs/types': 3.23.0
+            '@shikijs/types': 4.0.2
             '@shikijs/vscode-textmate': 10.0.2
             oniguruma-to-es: 4.3.5
 
-    '@shikijs/engine-oniguruma@3.23.0':
+    '@shikijs/engine-oniguruma@4.0.2':
         dependencies:
-            '@shikijs/types': 3.23.0
+            '@shikijs/types': 4.0.2
             '@shikijs/vscode-textmate': 10.0.2
 
-    '@shikijs/langs@3.23.0':
+    '@shikijs/langs@4.0.2':
         dependencies:
-            '@shikijs/types': 3.23.0
+            '@shikijs/types': 4.0.2
 
-    '@shikijs/themes@3.23.0':
+    '@shikijs/primitive@4.0.2':
         dependencies:
-            '@shikijs/types': 3.23.0
+            '@shikijs/types': 4.0.2
+            '@shikijs/vscode-textmate': 10.0.2
+            '@types/hast': 3.0.4
 
-    '@shikijs/types@3.23.0':
+    '@shikijs/themes@4.0.2':
+        dependencies:
+            '@shikijs/types': 4.0.2
+
+    '@shikijs/types@4.0.2':
         dependencies:
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
@@ -4787,12 +4379,12 @@ snapshots:
             '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
             '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-    '@tailwindcss/vite@4.2.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+    '@tailwindcss/vite@4.2.2(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
         dependencies:
             '@tailwindcss/node': 4.2.2
             '@tailwindcss/oxide': 4.2.2
             tailwindcss: 4.2.2
-            vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+            vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
     '@types/debug@4.1.13':
         dependencies:
@@ -4820,13 +4412,13 @@ snapshots:
         dependencies:
             '@types/unist': 3.0.3
 
-    '@types/node@24.12.0':
+    '@types/node@24.12.2':
         dependencies:
             undici-types: 7.16.0
 
     '@types/sax@1.2.7':
         dependencies:
-            '@types/node': 24.12.0
+            '@types/node': 24.12.2
 
     '@types/unist@2.0.11': {}
 
@@ -4834,12 +4426,12 @@ snapshots:
 
     '@ungap/structured-clone@1.3.0': {}
 
-    '@volar/kit@2.4.28(typescript@5.9.3)':
+    '@volar/kit@2.4.28(typescript@6.0.2)':
         dependencies:
             '@volar/language-service': 2.4.28
             '@volar/typescript': 2.4.28
             typesafe-path: 0.2.2
-            typescript: 5.9.3
+            typescript: 6.0.2
             vscode-languageserver-textdocument: 1.0.12
             vscode-uri: 3.1.0
 
@@ -4901,24 +4493,16 @@ snapshots:
             json-schema-traverse: 1.0.0
             require-from-string: 2.0.2
 
-    ansi-align@3.0.1:
-        dependencies:
-            string-width: 4.2.3
-
     ansi-regex@5.0.1: {}
-
-    ansi-regex@6.2.2: {}
 
     ansi-styles@4.3.0:
         dependencies:
             color-convert: 2.0.1
 
-    ansi-styles@6.2.3: {}
-
     anymatch@3.1.3:
         dependencies:
             normalize-path: 3.0.0
-            picomatch: 2.3.1
+            picomatch: 2.3.2
 
     arg@5.0.2: {}
 
@@ -4930,71 +4514,62 @@ snapshots:
 
     astring@1.9.0: {}
 
-    astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2):
+    astro@6.1.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(typescript@6.0.2)(yaml@2.8.3):
         dependencies:
-            '@astrojs/compiler': 2.13.1
-            '@astrojs/internal-helpers': 0.7.6
-            '@astrojs/markdown-remark': 6.3.11
+            '@astrojs/compiler': 3.0.1
+            '@astrojs/internal-helpers': 0.8.0
+            '@astrojs/markdown-remark': 7.1.0
             '@astrojs/telemetry': 3.3.0
             '@capsizecss/unpack': 4.0.0
+            '@clack/prompts': 1.2.0
             '@oslojs/encoding': 1.1.0
-            '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-            acorn: 8.16.0
+            '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
             aria-query: 5.3.2
             axobject-query: 4.1.0
-            boxen: 8.0.1
             ci-info: 4.4.0
             clsx: 2.1.1
-            common-ancestor-path: 1.0.1
+            common-ancestor-path: 2.0.0
             cookie: 1.1.1
-            cssesc: 3.0.0
-            debug: 4.4.3
-            deterministic-object-hash: 2.0.2
-            devalue: 5.6.4
-            diff: 8.0.3
-            dlv: 1.1.3
+            devalue: 5.7.1
+            diff: 8.0.4
             dset: 3.1.4
-            es-module-lexer: 1.7.0
-            esbuild: 0.27.4
-            estree-walker: 3.0.3
+            es-module-lexer: 2.0.0
+            esbuild: 0.27.7
             flattie: 1.1.1
             fontace: 0.4.1
             github-slugger: 2.0.0
             html-escaper: 3.0.3
             http-cache-semantics: 4.2.0
-            import-meta-resolve: 4.2.0
             js-yaml: 4.1.1
             magic-string: 0.30.21
             magicast: 0.5.2
             mrmime: 2.0.1
             neotraverse: 0.6.18
-            p-limit: 6.2.0
-            p-queue: 8.1.1
+            obug: 2.1.1
+            p-limit: 7.3.0
+            p-queue: 9.1.2
             package-manager-detector: 1.6.0
             piccolore: 0.1.3
-            picomatch: 4.0.3
-            prompts: 2.4.2
+            picomatch: 4.0.4
             rehype: 13.0.2
             semver: 7.7.4
-            shiki: 3.23.0
-            smol-toml: 1.6.0
+            shiki: 4.0.2
+            smol-toml: 1.6.1
             svgo: 4.0.1
-            tinyexec: 1.0.4
-            tinyglobby: 0.2.15
-            tsconfck: 3.1.6(typescript@5.9.3)
+            tinyclip: 0.1.12
+            tinyexec: 1.1.1
+            tinyglobby: 0.2.16
+            tsconfck: 3.1.6(typescript@6.0.2)
             ultrahtml: 1.6.0
             unifont: 0.7.4
             unist-util-visit: 5.1.0
-            unstorage: 1.17.4
+            unstorage: 1.17.5
             vfile: 6.0.3
-            vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
-            vitefu: 1.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+            vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+            vitefu: 1.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
             xxhash-wasm: 1.1.0
-            yargs-parser: 21.1.1
-            yocto-spinner: 0.2.3
-            zod: 3.25.76
-            zod-to-json-schema: 3.25.1(zod@3.25.76)
-            zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+            yargs-parser: 22.0.0
+            zod: 4.3.6
         optionalDependencies:
             sharp: 0.34.5
         transitivePeerDependencies:
@@ -5036,26 +4611,9 @@ snapshots:
 
     bail@2.0.2: {}
 
-    base-64@1.0.0: {}
-
     boolbase@1.0.0: {}
 
-    boxen@8.0.1:
-        dependencies:
-            ansi-align: 3.0.1
-            camelcase: 8.0.0
-            chalk: 5.6.2
-            cli-boxes: 3.0.0
-            string-width: 7.2.0
-            type-fest: 4.41.0
-            widest-line: 5.0.0
-            wrap-ansi: 9.0.2
-
-    camelcase@8.0.0: {}
-
     ccount@2.0.1: {}
-
-    chalk@5.6.2: {}
 
     character-entities-html4@2.1.0: {}
 
@@ -5074,8 +4632,6 @@ snapshots:
             readdirp: 5.0.0
 
     ci-info@4.4.0: {}
-
-    cli-boxes@3.0.0: {}
 
     cliui@8.0.1:
         dependencies:
@@ -5097,9 +4653,9 @@ snapshots:
 
     commander@11.1.0: {}
 
-    common-ancestor-path@1.0.1: {}
+    common-ancestor-path@2.0.0: {}
 
-    cookie-es@1.2.2: {}
+    cookie-es@1.2.3: {}
 
     cookie@1.1.1: {}
 
@@ -5127,8 +4683,6 @@ snapshots:
 
     css-what@6.2.2: {}
 
-    cssesc@3.0.0: {}
-
     csso@5.0.5:
         dependencies:
             css-tree: 2.2.1
@@ -5141,7 +4695,7 @@ snapshots:
         dependencies:
             character-entities: 2.0.2
 
-    defu@6.1.4: {}
+    defu@6.1.7: {}
 
     dequal@2.0.3: {}
 
@@ -5149,17 +4703,13 @@ snapshots:
 
     detect-libc@2.1.2: {}
 
-    deterministic-object-hash@2.0.2:
-        dependencies:
-            base-64: 1.0.0
-
-    devalue@5.6.4: {}
+    devalue@5.7.1: {}
 
     devlop@1.1.0:
         dependencies:
             dequal: 2.0.3
 
-    diff@8.0.3: {}
+    diff@8.0.4: {}
 
     dlv@1.1.3: {}
 
@@ -5188,20 +4738,18 @@ snapshots:
             '@emmetio/abbreviation': 2.3.3
             '@emmetio/css-abbreviation': 2.1.8
 
-    emoji-regex@10.6.0: {}
-
     emoji-regex@8.0.0: {}
 
     enhanced-resolve@5.20.1:
         dependencies:
             graceful-fs: 4.2.11
-            tapable: 2.3.0
+            tapable: 2.3.2
 
     entities@4.5.0: {}
 
     entities@6.0.1: {}
 
-    es-module-lexer@1.7.0: {}
+    es-module-lexer@2.0.0: {}
 
     esast-util-from-estree@2.0.0:
         dependencies:
@@ -5217,63 +4765,34 @@ snapshots:
             esast-util-from-estree: 2.0.0
             vfile-message: 4.0.3
 
-    esbuild@0.25.12:
+    esbuild@0.27.7:
         optionalDependencies:
-            '@esbuild/aix-ppc64': 0.25.12
-            '@esbuild/android-arm': 0.25.12
-            '@esbuild/android-arm64': 0.25.12
-            '@esbuild/android-x64': 0.25.12
-            '@esbuild/darwin-arm64': 0.25.12
-            '@esbuild/darwin-x64': 0.25.12
-            '@esbuild/freebsd-arm64': 0.25.12
-            '@esbuild/freebsd-x64': 0.25.12
-            '@esbuild/linux-arm': 0.25.12
-            '@esbuild/linux-arm64': 0.25.12
-            '@esbuild/linux-ia32': 0.25.12
-            '@esbuild/linux-loong64': 0.25.12
-            '@esbuild/linux-mips64el': 0.25.12
-            '@esbuild/linux-ppc64': 0.25.12
-            '@esbuild/linux-riscv64': 0.25.12
-            '@esbuild/linux-s390x': 0.25.12
-            '@esbuild/linux-x64': 0.25.12
-            '@esbuild/netbsd-arm64': 0.25.12
-            '@esbuild/netbsd-x64': 0.25.12
-            '@esbuild/openbsd-arm64': 0.25.12
-            '@esbuild/openbsd-x64': 0.25.12
-            '@esbuild/openharmony-arm64': 0.25.12
-            '@esbuild/sunos-x64': 0.25.12
-            '@esbuild/win32-arm64': 0.25.12
-            '@esbuild/win32-ia32': 0.25.12
-            '@esbuild/win32-x64': 0.25.12
-
-    esbuild@0.27.4:
-        optionalDependencies:
-            '@esbuild/aix-ppc64': 0.27.4
-            '@esbuild/android-arm': 0.27.4
-            '@esbuild/android-arm64': 0.27.4
-            '@esbuild/android-x64': 0.27.4
-            '@esbuild/darwin-arm64': 0.27.4
-            '@esbuild/darwin-x64': 0.27.4
-            '@esbuild/freebsd-arm64': 0.27.4
-            '@esbuild/freebsd-x64': 0.27.4
-            '@esbuild/linux-arm': 0.27.4
-            '@esbuild/linux-arm64': 0.27.4
-            '@esbuild/linux-ia32': 0.27.4
-            '@esbuild/linux-loong64': 0.27.4
-            '@esbuild/linux-mips64el': 0.27.4
-            '@esbuild/linux-ppc64': 0.27.4
-            '@esbuild/linux-riscv64': 0.27.4
-            '@esbuild/linux-s390x': 0.27.4
-            '@esbuild/linux-x64': 0.27.4
-            '@esbuild/netbsd-arm64': 0.27.4
-            '@esbuild/netbsd-x64': 0.27.4
-            '@esbuild/openbsd-arm64': 0.27.4
-            '@esbuild/openbsd-x64': 0.27.4
-            '@esbuild/openharmony-arm64': 0.27.4
-            '@esbuild/sunos-x64': 0.27.4
-            '@esbuild/win32-arm64': 0.27.4
-            '@esbuild/win32-ia32': 0.27.4
-            '@esbuild/win32-x64': 0.27.4
+            '@esbuild/aix-ppc64': 0.27.7
+            '@esbuild/android-arm': 0.27.7
+            '@esbuild/android-arm64': 0.27.7
+            '@esbuild/android-x64': 0.27.7
+            '@esbuild/darwin-arm64': 0.27.7
+            '@esbuild/darwin-x64': 0.27.7
+            '@esbuild/freebsd-arm64': 0.27.7
+            '@esbuild/freebsd-x64': 0.27.7
+            '@esbuild/linux-arm': 0.27.7
+            '@esbuild/linux-arm64': 0.27.7
+            '@esbuild/linux-ia32': 0.27.7
+            '@esbuild/linux-loong64': 0.27.7
+            '@esbuild/linux-mips64el': 0.27.7
+            '@esbuild/linux-ppc64': 0.27.7
+            '@esbuild/linux-riscv64': 0.27.7
+            '@esbuild/linux-s390x': 0.27.7
+            '@esbuild/linux-x64': 0.27.7
+            '@esbuild/netbsd-arm64': 0.27.7
+            '@esbuild/netbsd-x64': 0.27.7
+            '@esbuild/openbsd-arm64': 0.27.7
+            '@esbuild/openbsd-x64': 0.27.7
+            '@esbuild/openharmony-arm64': 0.27.7
+            '@esbuild/sunos-x64': 0.27.7
+            '@esbuild/win32-arm64': 0.27.7
+            '@esbuild/win32-ia32': 0.27.7
+            '@esbuild/win32-x64': 0.27.7
 
     escalade@3.2.0: {}
 
@@ -5320,20 +4839,31 @@ snapshots:
 
     fast-deep-equal@3.1.3: {}
 
+    fast-string-truncated-width@1.2.1: {}
+
+    fast-string-width@1.1.0:
+        dependencies:
+            fast-string-truncated-width: 1.2.1
+
     fast-uri@3.1.0: {}
+
+    fast-wrap-ansi@0.1.6:
+        dependencies:
+            fast-string-width: 1.1.0
 
     fast-xml-builder@1.1.4:
         dependencies:
-            path-expression-matcher: 1.2.0
+            path-expression-matcher: 1.4.0
 
-    fast-xml-parser@5.4.1:
+    fast-xml-parser@5.5.11:
         dependencies:
             fast-xml-builder: 1.1.4
-            strnum: 2.2.1
+            path-expression-matcher: 1.4.0
+            strnum: 2.2.3
 
-    fdir@6.5.0(picomatch@4.0.3):
+    fdir@6.5.0(picomatch@4.0.4):
         optionalDependencies:
-            picomatch: 4.0.3
+            picomatch: 4.0.4
 
     flattie@1.1.1: {}
 
@@ -5350,17 +4880,15 @@ snapshots:
 
     get-caller-file@2.0.5: {}
 
-    get-east-asian-width@1.5.0: {}
-
     github-slugger@2.0.0: {}
 
     graceful-fs@4.2.11: {}
 
-    h3@1.15.9:
+    h3@1.15.11:
         dependencies:
-            cookie-es: 1.2.2
+            cookie-es: 1.2.3
             crossws: 0.3.5
-            defu: 6.1.4
+            defu: 6.1.7
             destr: 2.0.5
             iron-webcrypto: 1.2.1
             node-mock-http: 1.0.4
@@ -5504,8 +5032,6 @@ snapshots:
 
     ignore@7.0.5: {}
 
-    import-meta-resolve@4.2.0: {}
-
     inline-style-parser@0.2.7: {}
 
     iron-webcrypto@1.2.1: {}
@@ -5546,8 +5072,6 @@ snapshots:
     jsonc-parser@2.3.1: {}
 
     jsonc-parser@3.3.1: {}
-
-    kleur@3.0.3: {}
 
     kleur@4.1.5: {}
 
@@ -5602,7 +5126,7 @@ snapshots:
 
     longest-streak@3.1.0: {}
 
-    lru-cache@11.2.7: {}
+    lru-cache@11.3.3: {}
 
     magic-string@0.30.21:
         dependencies:
@@ -6081,6 +5605,8 @@ snapshots:
         dependencies:
             boolbase: 1.0.0
 
+    obug@2.1.1: {}
+
     ofetch@1.5.1:
         dependencies:
             destr: 2.0.5
@@ -6097,16 +5623,16 @@ snapshots:
             regex: 6.1.0
             regex-recursion: 6.0.2
 
-    p-limit@6.2.0:
+    p-limit@7.3.0:
         dependencies:
             yocto-queue: 1.2.2
 
-    p-queue@8.1.1:
+    p-queue@9.1.2:
         dependencies:
             eventemitter3: 5.0.4
-            p-timeout: 6.1.4
+            p-timeout: 7.0.1
 
-    p-timeout@6.1.4: {}
+    p-timeout@7.0.1: {}
 
     package-manager-detector@1.6.0: {}
 
@@ -6135,17 +5661,17 @@ snapshots:
 
     path-browserify@1.0.1: {}
 
-    path-expression-matcher@1.2.0: {}
+    path-expression-matcher@1.4.0: {}
 
     piccolore@0.1.3: {}
 
     picocolors@1.1.1: {}
 
-    picomatch@2.3.1: {}
+    picomatch@2.3.2: {}
 
-    picomatch@4.0.3: {}
+    picomatch@4.0.4: {}
 
-    postcss@8.5.8:
+    postcss@8.5.9:
         dependencies:
             nanoid: 3.3.11
             picocolors: 1.1.1
@@ -6154,34 +5680,29 @@ snapshots:
     prettier-plugin-astro@0.14.1:
         dependencies:
             '@astrojs/compiler': 2.13.1
-            prettier: 3.5.3
+            prettier: 3.8.1
             sass-formatter: 0.7.9
 
-    prettier-plugin-tailwindcss@0.6.14(prettier-plugin-astro@0.14.1)(prettier@3.5.3):
+    prettier-plugin-tailwindcss@0.7.2(prettier-plugin-astro@0.14.1)(prettier@3.8.1):
         dependencies:
-            prettier: 3.5.3
+            prettier: 3.8.1
         optionalDependencies:
             prettier-plugin-astro: 0.14.1
 
-    prettier@3.5.3: {}
+    prettier@3.8.1: {}
 
-    pretty-quick@4.2.2(prettier@3.5.3):
+    pretty-quick@4.2.2(prettier@3.8.1):
         dependencies:
             '@pkgr/core': 0.2.9
             ignore: 7.0.5
             mri: 1.2.0
             picocolors: 1.1.1
-            picomatch: 4.0.3
-            prettier: 3.5.3
+            picomatch: 4.0.4
+            prettier: 3.8.1
             tinyexec: 0.3.2
             tslib: 2.8.1
 
     prismjs@1.30.0: {}
-
-    prompts@2.4.2:
-        dependencies:
-            kleur: 3.0.3
-            sisteransi: 1.0.5
 
     property-information@7.1.0: {}
 
@@ -6344,35 +5865,35 @@ snapshots:
             retext-stringify: 4.0.0
             unified: 11.0.5
 
-    rollup@4.59.0:
+    rollup@4.60.1:
         dependencies:
             '@types/estree': 1.0.8
         optionalDependencies:
-            '@rollup/rollup-android-arm-eabi': 4.59.0
-            '@rollup/rollup-android-arm64': 4.59.0
-            '@rollup/rollup-darwin-arm64': 4.59.0
-            '@rollup/rollup-darwin-x64': 4.59.0
-            '@rollup/rollup-freebsd-arm64': 4.59.0
-            '@rollup/rollup-freebsd-x64': 4.59.0
-            '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
-            '@rollup/rollup-linux-arm-musleabihf': 4.59.0
-            '@rollup/rollup-linux-arm64-gnu': 4.59.0
-            '@rollup/rollup-linux-arm64-musl': 4.59.0
-            '@rollup/rollup-linux-loong64-gnu': 4.59.0
-            '@rollup/rollup-linux-loong64-musl': 4.59.0
-            '@rollup/rollup-linux-ppc64-gnu': 4.59.0
-            '@rollup/rollup-linux-ppc64-musl': 4.59.0
-            '@rollup/rollup-linux-riscv64-gnu': 4.59.0
-            '@rollup/rollup-linux-riscv64-musl': 4.59.0
-            '@rollup/rollup-linux-s390x-gnu': 4.59.0
-            '@rollup/rollup-linux-x64-gnu': 4.59.0
-            '@rollup/rollup-linux-x64-musl': 4.59.0
-            '@rollup/rollup-openbsd-x64': 4.59.0
-            '@rollup/rollup-openharmony-arm64': 4.59.0
-            '@rollup/rollup-win32-arm64-msvc': 4.59.0
-            '@rollup/rollup-win32-ia32-msvc': 4.59.0
-            '@rollup/rollup-win32-x64-gnu': 4.59.0
-            '@rollup/rollup-win32-x64-msvc': 4.59.0
+            '@rollup/rollup-android-arm-eabi': 4.60.1
+            '@rollup/rollup-android-arm64': 4.60.1
+            '@rollup/rollup-darwin-arm64': 4.60.1
+            '@rollup/rollup-darwin-x64': 4.60.1
+            '@rollup/rollup-freebsd-arm64': 4.60.1
+            '@rollup/rollup-freebsd-x64': 4.60.1
+            '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+            '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+            '@rollup/rollup-linux-arm64-gnu': 4.60.1
+            '@rollup/rollup-linux-arm64-musl': 4.60.1
+            '@rollup/rollup-linux-loong64-gnu': 4.60.1
+            '@rollup/rollup-linux-loong64-musl': 4.60.1
+            '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+            '@rollup/rollup-linux-ppc64-musl': 4.60.1
+            '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+            '@rollup/rollup-linux-riscv64-musl': 4.60.1
+            '@rollup/rollup-linux-s390x-gnu': 4.60.1
+            '@rollup/rollup-linux-x64-gnu': 4.60.1
+            '@rollup/rollup-linux-x64-musl': 4.60.1
+            '@rollup/rollup-openbsd-x64': 4.60.1
+            '@rollup/rollup-openharmony-arm64': 4.60.1
+            '@rollup/rollup-win32-arm64-msvc': 4.60.1
+            '@rollup/rollup-win32-ia32-msvc': 4.60.1
+            '@rollup/rollup-win32-x64-gnu': 4.60.1
+            '@rollup/rollup-win32-x64-msvc': 4.60.1
             fsevents: 2.3.3
 
     s.color@0.0.15: {}
@@ -6416,14 +5937,14 @@ snapshots:
             '@img/sharp-win32-ia32': 0.34.5
             '@img/sharp-win32-x64': 0.34.5
 
-    shiki@3.23.0:
+    shiki@4.0.2:
         dependencies:
-            '@shikijs/core': 3.23.0
-            '@shikijs/engine-javascript': 3.23.0
-            '@shikijs/engine-oniguruma': 3.23.0
-            '@shikijs/langs': 3.23.0
-            '@shikijs/themes': 3.23.0
-            '@shikijs/types': 3.23.0
+            '@shikijs/core': 4.0.2
+            '@shikijs/engine-javascript': 4.0.2
+            '@shikijs/engine-oniguruma': 4.0.2
+            '@shikijs/langs': 4.0.2
+            '@shikijs/themes': 4.0.2
+            '@shikijs/types': 4.0.2
             '@shikijs/vscode-textmate': 10.0.2
             '@types/hast': 3.0.4
 
@@ -6433,12 +5954,12 @@ snapshots:
 
     sitemap@9.0.1:
         dependencies:
-            '@types/node': 24.12.0
+            '@types/node': 24.12.2
             '@types/sax': 1.2.7
             arg: 5.0.2
             sax: 1.6.0
 
-    smol-toml@1.6.0: {}
+    smol-toml@1.6.1: {}
 
     source-map-js@1.2.1: {}
 
@@ -6454,12 +5975,6 @@ snapshots:
             is-fullwidth-code-point: 3.0.0
             strip-ansi: 6.0.1
 
-    string-width@7.2.0:
-        dependencies:
-            emoji-regex: 10.6.0
-            get-east-asian-width: 1.5.0
-            strip-ansi: 7.2.0
-
     stringify-entities@4.0.4:
         dependencies:
             character-entities-html4: 2.1.0
@@ -6469,11 +5984,7 @@ snapshots:
         dependencies:
             ansi-regex: 5.0.1
 
-    strip-ansi@7.2.0:
-        dependencies:
-            ansi-regex: 6.2.2
-
-    strnum@2.2.1: {}
+    strnum@2.2.3: {}
 
     style-to-js@1.1.21:
         dependencies:
@@ -6499,30 +6010,30 @@ snapshots:
 
     tailwindcss@4.2.2: {}
 
-    tapable@2.3.0: {}
+    tapable@2.3.2: {}
 
     tiny-inflate@1.0.3: {}
 
+    tinyclip@0.1.12: {}
+
     tinyexec@0.3.2: {}
 
-    tinyexec@1.0.4: {}
+    tinyexec@1.1.1: {}
 
-    tinyglobby@0.2.15:
+    tinyglobby@0.2.16:
         dependencies:
-            fdir: 6.5.0(picomatch@4.0.3)
-            picomatch: 4.0.3
+            fdir: 6.5.0(picomatch@4.0.4)
+            picomatch: 4.0.4
 
     trim-lines@3.0.1: {}
 
     trough@2.2.0: {}
 
-    tsconfck@3.1.6(typescript@5.9.3):
+    tsconfck@3.1.6(typescript@6.0.2):
         optionalDependencies:
-            typescript: 5.9.3
+            typescript: 6.0.2
 
     tslib@2.8.1: {}
-
-    type-fest@4.41.0: {}
 
     typesafe-path@0.2.2: {}
 
@@ -6530,7 +6041,7 @@ snapshots:
         dependencies:
             semver: 7.7.4
 
-    typescript@5.9.3: {}
+    typescript@6.0.2: {}
 
     ufo@1.6.3: {}
 
@@ -6602,13 +6113,13 @@ snapshots:
             unist-util-is: 6.0.1
             unist-util-visit-parents: 6.0.2
 
-    unstorage@1.17.4:
+    unstorage@1.17.5:
         dependencies:
             anymatch: 3.1.3
             chokidar: 5.0.0
             destr: 2.0.5
-            h3: 1.15.9
-            lru-cache: 11.2.7
+            h3: 1.15.11
+            lru-cache: 11.3.3
             node-fetch-native: 1.6.7
             ofetch: 1.5.1
             ufo: 1.6.3
@@ -6628,24 +6139,24 @@ snapshots:
             '@types/unist': 3.0.3
             vfile-message: 4.0.3
 
-    vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2):
+    vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
         dependencies:
-            esbuild: 0.25.12
-            fdir: 6.5.0(picomatch@4.0.3)
-            picomatch: 4.0.3
-            postcss: 8.5.8
-            rollup: 4.59.0
-            tinyglobby: 0.2.15
+            esbuild: 0.27.7
+            fdir: 6.5.0(picomatch@4.0.4)
+            picomatch: 4.0.4
+            postcss: 8.5.9
+            rollup: 4.60.1
+            tinyglobby: 0.2.16
         optionalDependencies:
-            '@types/node': 24.12.0
+            '@types/node': 24.12.2
             fsevents: 2.3.3
             jiti: 2.6.1
             lightningcss: 1.32.0
-            yaml: 2.8.2
+            yaml: 2.8.3
 
-    vitefu@1.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)):
+    vitefu@1.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
         optionalDependencies:
-            vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+            vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
     volar-service-css@0.0.70(@volar/language-service@2.4.28):
         dependencies:
@@ -6672,12 +6183,12 @@ snapshots:
         optionalDependencies:
             '@volar/language-service': 2.4.28
 
-    volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.5.3):
+    volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.8.1):
         dependencies:
             vscode-uri: 3.1.0
         optionalDependencies:
             '@volar/language-service': 2.4.28
-            prettier: 3.5.3
+            prettier: 3.8.1
 
     volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
         dependencies:
@@ -6748,21 +6259,11 @@ snapshots:
 
     which-pm-runs@1.1.0: {}
 
-    widest-line@5.0.0:
-        dependencies:
-            string-width: 7.2.0
-
     wrap-ansi@7.0.0:
         dependencies:
             ansi-styles: 4.3.0
             string-width: 4.2.3
             strip-ansi: 6.0.1
-
-    wrap-ansi@9.0.2:
-        dependencies:
-            ansi-styles: 6.2.3
-            string-width: 7.2.0
-            strip-ansi: 7.2.0
 
     xxhash-wasm@1.1.0: {}
 
@@ -6773,7 +6274,7 @@ snapshots:
             '@vscode/l10n': 0.0.18
             ajv: 8.18.0
             ajv-draft-04: 1.0.0(ajv@8.18.0)
-            prettier: 3.5.3
+            prettier: 3.8.1
             request-light: 0.5.8
             vscode-json-languageservice: 4.1.8
             vscode-languageserver: 9.0.1
@@ -6784,9 +6285,11 @@ snapshots:
 
     yaml@2.7.1: {}
 
-    yaml@2.8.2: {}
+    yaml@2.8.3: {}
 
     yargs-parser@21.1.1: {}
+
+    yargs-parser@22.0.0: {}
 
     yargs@17.7.2:
         dependencies:
@@ -6799,23 +6302,6 @@ snapshots:
             yargs-parser: 21.1.1
 
     yocto-queue@1.2.2: {}
-
-    yocto-spinner@0.2.3:
-        dependencies:
-            yoctocolors: 2.1.2
-
-    yoctocolors@2.1.2: {}
-
-    zod-to-json-schema@3.25.1(zod@3.25.76):
-        dependencies:
-            zod: 3.25.76
-
-    zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
-        dependencies:
-            typescript: 5.9.3
-            zod: 3.25.76
-
-    zod@3.25.76: {}
 
     zod@4.3.6: {}
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
 import { glob } from 'astro/loaders'
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
+import { z } from 'zod'
 
 const blog = defineCollection({
     // Load Markdown and MDX files in the `src/content/blog/` directory.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,8 @@
     "exclude": ["dist"],
     "compilerOptions": {
         "strictNullChecks": true,
-        "baseUrl": "./src",
         "paths": {
-            "@/*": ["*"]
+            "@/*": ["./src/*"]
         }
     }
 }


### PR DESCRIPTION
- astro 5 → 6, @astrojs/mdx 4 → 5
- typescript 5 → 6; fix deprecated baseUrl in tsconfig
- prettier 3.5 → 3.8, prettier-plugin-tailwindcss 0.6 → 0.7
- minor bumps: @astrojs/rss, @astrojs/sitemap
- add zod as direct dep (z re-export removed from astro:content in Astro 6)